### PR TITLE
Optimize tile scheduling and base layer rendering (2.3x faster)

### DIFF
--- a/internal/cog/mmap_other.go
+++ b/internal/cog/mmap_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package cog
+
+import "fmt"
+
+// mmapFile is not supported on non-Unix platforms.
+func mmapFile(fd uintptr, size int) ([]byte, error) {
+	return nil, fmt.Errorf("memory mapping is not supported on this platform")
+}
+
+// munmapFile is a no-op on non-Unix platforms.
+func munmapFile(data []byte) error {
+	return nil
+}

--- a/internal/cog/mmap_unix.go
+++ b/internal/cog/mmap_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package cog
+
+import "syscall"
+
+// mmapFile memory-maps a file read-only. The fd can be closed after mapping.
+func mmapFile(fd uintptr, size int) ([]byte, error) {
+	return syscall.Mmap(int(fd), 0, size, syscall.PROT_READ, syscall.MAP_PRIVATE)
+}
+
+// munmapFile releases a memory mapping created by mmapFile.
+func munmapFile(data []byte) error {
+	return syscall.Munmap(data)
+}


### PR DESCRIPTION
Replace static worker partitioning with a batch-based work queue that distributes small Hilbert-contiguous tile batches via a channel, fixing load imbalance where edge workers with empty tiles would finish early.

Eliminate three major per-pixel hot spots identified via CPU profiling:
- Replace string-keyed tile cache with integer reader IDs (was 18% CPU on FNV hash iterating file path strings ~1M times per tile)
- Use type-specific pixel reads (YCbCrAt/RGBAAt) instead of the image.At() interface which heap-allocated every color value (was 10%)
- Pre-compute source overlap and overview levels per tile instead of per pixel, removing redundant OverviewForZoom calls (was 6%)

Demo benchmark: 3m08s → 1m21s on 10 cores with 36 Swiss COG sources.