### PR TITLE
Leaked RGBA for gray tiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,8 +58,11 @@ internal/
 - LRU tile cache prevents redundant reads (~256 tiles, configurable)
 - Tiles stored as encoded bytes (PNG/WebP/JPEG) in memory: 5-25x smaller than raw pixels
 - Continuous disk spilling via dedicated I/O goroutine with configurable memory backpressure (auto ~90% of RAM)
+- Memory limit accounts for both encoded tile data and Go map overhead (uniform entries, disk index entries) to prevent actual usage from exceeding the configured limit
+- Map pre-allocation sized to the working set (tiles that fit in memory), not the total tile count, avoiding multi-GB upfront waste on empty hash buckets
 - Uniform tiles (single color) stored as 4 bytes, never spilled to disk
 - `sync.Pool` for `*image.RGBA` buffers: render, downsample, and decode paths reuse 256 KB buffers instead of allocating/GC'ing per tile
+- Gray tile RGBA expansions (from `AsImage()`) cached in the TileData so `Release()` returns them to the pool
 - PMTiles writer uses temp file for tile data (only directory entries in memory)
 - Pyramid downsampling avoids redundant source reads for lower zoom levels
 

--- a/internal/tile/tiledata.go
+++ b/internal/tile/tiledata.go
@@ -117,16 +117,16 @@ func (t *TileData) ToRGBA() *image.RGBA {
 
 // AsImage returns an image.Image suitable for encoders. For full tiles it
 // returns the underlying *image.RGBA (so encoders can type-switch to the fast
-// path). For gray tiles it expands to RGBA (encoders expect color output).
-// For uniform tiles it returns *TileData itself (which implements
-// image.Image via generic At() — trivially fast for uniform data).
+// path). For gray tiles it expands to RGBA and caches the result in t.img
+// so that Release() can return it to the pool. For uniform tiles it returns
+// *TileData itself (which implements image.Image via generic At()).
 func (t *TileData) AsImage() image.Image {
 	if t.img != nil {
 		return t.img
 	}
 	if t.gray != nil {
-		// Encoders (PNG, JPEG, WebP) produce color output, so expand to RGBA.
-		return t.ToRGBA()
+		t.img = t.ToRGBA()
+		return t.img
 	}
 	return t
 }


### PR DESCRIPTION
In tiledata.go, AsImage() calls ToRGBA() for gray tiles, which allocates via GetRGBA() but the returned image is never returned to the pool. This creates 256KB of garbage per gray tile that the GC must collect, adding pressure.