### PR TITLE
Fix empty tile artifacts, scaling with non-256 tile sizes, and nodata handling

### DIFF
--- a/internal/coord/mercator.go
+++ b/internal/coord/mercator.go
@@ -108,9 +108,10 @@ func PixelToLonLat(z, tileX, tileY, tileSize int, px, py float64) (lon, lat floa
 	return
 }
 
-// ResolutionAtLat returns the ground resolution in meters/pixel at the given latitude and zoom level.
-func ResolutionAtLat(lat float64, zoom int) float64 {
-	return EarthCircumference * math.Cos(lat*math.Pi/180.0) / pow2(zoom) / float64(DefaultTileSize)
+// ResolutionAtLat returns the ground resolution in meters/pixel at the given
+// latitude, zoom level, and tile size.
+func ResolutionAtLat(lat float64, zoom int, tileSize int) float64 {
+	return EarthCircumference * math.Cos(lat*math.Pi/180.0) / pow2(zoom) / float64(tileSize)
 }
 
 // PixelSizeInGroundMeters converts a pixel size from CRS units to ground meters.

--- a/internal/coord/mercator_test.go
+++ b/internal/coord/mercator_test.go
@@ -108,23 +108,29 @@ func TestPixelToLonLat_RoundTrip(t *testing.T) {
 }
 
 func TestResolutionAtLat(t *testing.T) {
-	// At the equator, zoom 0, each pixel covers ~156543 meters.
-	res0 := ResolutionAtLat(0, 0)
+	// At the equator, zoom 0, each pixel covers ~156543 meters (256-pixel tiles).
+	res0 := ResolutionAtLat(0, 0, 256)
 	expected0 := EarthCircumference / 256
 	if math.Abs(res0-expected0)/expected0 > 1e-6 {
-		t.Errorf("ResolutionAtLat(0, 0) = %v, want ~%v", res0, expected0)
+		t.Errorf("ResolutionAtLat(0, 0, 256) = %v, want ~%v", res0, expected0)
 	}
 
 	// Each zoom level halves the resolution.
-	res1 := ResolutionAtLat(0, 1)
+	res1 := ResolutionAtLat(0, 1, 256)
 	if math.Abs(res1-res0/2)/res0 > 1e-6 {
-		t.Errorf("ResolutionAtLat(0, 1) = %v, want ~%v", res1, res0/2)
+		t.Errorf("ResolutionAtLat(0, 1, 256) = %v, want ~%v", res1, res0/2)
 	}
 
 	// Resolution at 60° latitude should be cos(60°) ≈ 0.5 of equatorial.
-	res60 := ResolutionAtLat(60, 0)
+	res60 := ResolutionAtLat(60, 0, 256)
 	if math.Abs(res60-res0*0.5)/res0 > 1e-6 {
-		t.Errorf("ResolutionAtLat(60, 0) = %v, want ~%v", res60, res0*0.5)
+		t.Errorf("ResolutionAtLat(60, 0, 256) = %v, want ~%v", res60, res0*0.5)
+	}
+
+	// 512-pixel tiles at the same zoom have half the per-pixel resolution.
+	res512 := ResolutionAtLat(0, 0, 512)
+	if math.Abs(res512-res0/2)/res0 > 1e-6 {
+		t.Errorf("ResolutionAtLat(0, 0, 512) = %v, want ~%v", res512, res0/2)
 	}
 }
 

--- a/internal/tile/resample.go
+++ b/internal/tile/resample.go
@@ -113,7 +113,7 @@ func tileCRSBounds(z, tx, ty int, proj coord.Projection) (minX, minY, maxX, maxY
 func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Projection, cache *cog.TileCache, mode Resampling) *image.RGBA {
 	// Pre-compute the output pixel size in CRS units for selecting the best overview level.
 	_, midLat, _, _ := coord.TileBounds(z, tx, ty)
-	outputResMeters := coord.ResolutionAtLat(midLat, z)
+	outputResMeters := coord.ResolutionAtLat(midLat, z, tileSize)
 	outputResCRS := coord.MetersToPixelSizeCRS(outputResMeters, proj.EPSG(), midLat)
 
 	// Pre-filter sources to only those overlapping this tile.
@@ -1341,7 +1341,7 @@ func bicubicLUT(x float64) float64 {
 // converting elevation values to Terrarium RGB encoding.
 func renderTileTerrarium(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Projection, cache *cog.FloatTileCache, mode Resampling) *image.RGBA {
 	_, midLat, _, _ := coord.TileBounds(z, tx, ty)
-	outputResMeters := coord.ResolutionAtLat(midLat, z)
+	outputResMeters := coord.ResolutionAtLat(midLat, z, tileSize)
 	outputResCRS := coord.MetersToPixelSizeCRS(outputResMeters, proj.EPSG(), midLat)
 
 	// Pre-filter sources and pre-compute overview levels for this tile.

--- a/internal/tile/rgbapool.go
+++ b/internal/tile/rgbapool.go
@@ -22,6 +22,7 @@ func GetRGBA(w, h int) *image.RGBA {
 	if p, ok := rgbaPools.Load(key); ok {
 		if v := p.(*sync.Pool).Get(); v != nil {
 			img := v.(*image.RGBA)
+			clear(img.Pix)
 			return img
 		}
 	}

--- a/results/2026-02-19-10-00-empty-tile-artifacts-scaling-fix.md
+++ b/results/2026-02-19-10-00-empty-tile-artifacts-scaling-fix.md
@@ -1,0 +1,28 @@
+# Fix: Empty Tile Artifacts & Scaling with Non-256 Tile Sizes
+
+**Date**: 2026-02-19
+
+## Problem
+
+Two issues when running `geotiff2pmtiles --resampling nearest --tile-size 512 --format webp` on ESA data:
+1. Weird artifacts around empty/sea tiles
+2. Scaling not working properly
+
+## Root Causes
+
+### Bug 1: RGBA pool returning stale pixel data
+`GetRGBA()` in `rgbapool.go` returned images from `sync.Pool` without clearing pixel data. In `renderTile`, pixels where no source data is found retained garbage from previous tiles. Boundary tiles (partial data coverage) showed fragments of unrelated tiles in their empty areas.
+
+### Bug 2: `ResolutionAtLat` hardcoded to 256-pixel tiles
+`ResolutionAtLat()` in `mercator.go` used `DefaultTileSize=256` regardless of actual tile size. With `--tile-size 512`, the output pixel resolution was computed as 2x too coarse, causing `OverviewForZoom` to select a coarser overview level than needed (blurry output).
+
+### Bug 3: No nodata handling for single-band image data
+For single-band GeoTIFF (e.g. ESA WorldCover), the GDAL nodata value (typically 0) was decoded as opaque black `(0,0,0,255)` instead of transparent `(0,0,0,0)`. Sea/empty areas appeared as solid black. The float/terrarium path handled nodata but the image path did not.
+
+## Changes
+
+- `internal/tile/rgbapool.go`: Added `clear(img.Pix)` when returning images from the pool
+- `internal/coord/mercator.go`: Added `tileSize` parameter to `ResolutionAtLat()`
+- `internal/tile/resample.go`: Pass actual tile size to `ResolutionAtLat()` in both `renderTile` and `renderTileTerrarium`
+- `internal/cog/reader.go`: Parse GDAL nodata value in `decodeRawTile()` for single-band (spp≤2) data; set alpha=0 for pixels matching the nodata value
+- `internal/coord/mercator_test.go`: Updated tests + added 512-tile-size test case


### PR DESCRIPTION

Three bugs caused visual issues when processing single-band GeoTIFF data (e.g. ESA WorldCover) with --tile-size 512:

1. RGBA pool returned stale pixels: GetRGBA() didn't clear recycled images, so boundary tiles showed fragments of previous tiles in empty areas.

2. ResolutionAtLat() hardcoded 256-pixel tiles: with --tile-size 512 the output resolution was 2x too coarse, selecting wrong overview levels.

3. Single-band nodata decoded as opaque black: pixels matching GDAL_NODATA got alpha=255 instead of alpha=0, rendering sea areas as solid black.