### PR TITLE
Fix nodata pixels blocking source fallthrough in tile rendering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,6 +63,7 @@ internal/
 - Uniform tiles (single color) stored as 4 bytes, never spilled to disk
 - `sync.Pool` for `*image.RGBA` buffers: render, downsample, and decode paths reuse 256 KB buffers (zeroed on get) instead of allocating/GC'ing per tile
 - Single-band nodata pixels decoded as transparent (alpha=0) so resampling/downsampling automatically excludes them
+- Source fallthrough on nodata: transparent (alpha=0) samples are skipped and the next source is tried, preventing holes in one source from blocking valid data in another and eliminating all-transparent tiles from the pyramid
 - Gray tile RGBA expansions (from `AsImage()`) cached in the TileData so `Release()` returns them to the pool
 - PMTiles writer uses temp file for tile data (only directory entries in memory)
 - Pyramid downsampling avoids redundant source reads for lower zoom levels

--- a/internal/tile/resample.go
+++ b/internal/tile/resample.go
@@ -206,6 +206,9 @@ func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.
 		if err != nil {
 			continue
 		}
+		if aa == 0 {
+			continue // nodata/transparent — try next source
+		}
 		return rr, gg, bb, aa, true
 	}
 	return 0, 0, 0, 0, false

--- a/results/2026-02-20-10-00-nodata-source-fallthrough.md
+++ b/results/2026-02-20-10-00-nodata-source-fallthrough.md
@@ -1,0 +1,40 @@
+# Fix: Nodata/Transparent Pixels Blocking Source Fallthrough
+
+**Date**: 2026-02-20
+
+## Problem
+
+PMTiles output shows issues in areas with no data (holes). Tiles within a source's
+bounding box but containing only nodata pixels are incorrectly emitted as non-empty,
+and holes in one source prevent valid data from subsequent sources from being used.
+
+## Root Cause
+
+`sampleFromTileSources` returned `found=true` for any successfully-read pixel,
+including fully transparent (alpha=0) ones. This caused:
+
+1. **Source blocking**: When source A has nodata at a coordinate but source B has
+   valid data, source A's transparent pixel was returned as "found" and source B
+   was never checked — leaving holes in the output.
+
+2. **False non-empty tiles**: `renderTile` set `hasData=true` for every "found"
+   pixel regardless of alpha. Tiles entirely within a source's bounding box but
+   in a nodata region (e.g. ocean in ESA WorldCover) were encoded and stored as
+   all-transparent tiles through the entire zoom pyramid. For JPEG output (no
+   alpha support), these appeared as solid black tiles.
+
+The float/terrarium path (`sampleFromTileSourcesFloat`) already handled this
+correctly by skipping NaN/nodata values and trying the next source.
+
+## Fix
+
+In `sampleFromTileSources`: after reading a pixel, check `alpha == 0` and
+`continue` to the next source instead of returning. Only pixels with alpha > 0
+are returned as "found". Semi-transparent pixels from resampling near data edges
+(e.g. bilinear interpolation between data and nodata) are correctly preserved
+since they have alpha > 0.
+
+## Changes
+
+- `internal/tile/resample.go`: Skip alpha=0 results in `sampleFromTileSources`
+- `DESIGN.md`: Added "Nodata-aware source fallthrough" design decision


### PR DESCRIPTION
sampleFromTileSources returned found=true for transparent (alpha=0) pixels, preventing subsequent sources from filling holes and causing all-transparent tiles to cascade through the zoom pyramid. Skip alpha=0 results and try the next source instead, matching the existing behavior in the float/terrarium path.