### PR TITLE
Add --fill-color to geotiff2pmtiles for transparent/nodata substitution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,11 @@ internal/
 8. **Encode**: JPEG/PNG/WebP/Terrarium encoding
 9. **Write**: Two-pass PMTiles assembly (temp file for tile data, then final archive with clustering)
 
+Empty tile filling (`--fill-color`) uses the same color transformation model as
+`pmtransform`: transparent/nodata pixels in rendered tiles are substituted with
+the target color, nil-child quadrants during downsampling become fill tiles, and
+solid-color tiles are generated for tile positions with no source data.
+
 ## Transform Pipeline (pmtransform)
 
 `pmtransform` reads an existing PMTiles archive and produces a new one with modifications.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,11 +133,13 @@ Empty tiles and transparent/nodata pixels should be modeled as a **color transfo
   Downsampling does not yet apply a fill-color transformation to transparent pixels
   within tiles or nil-child quadrants — transparent remains transparent.
 
-- **Implemented**: Color transform applied only at the source level. When `FillColor`
-  is set: (1) max-zoom decoded tiles — transparent pixels → fill before packing;
-  (2) downsampling — nil children are substituted with fill tiles *before* calling
-  downsample, so the existing downsample code receives 4 tiles and operates
-  normally. No transform in the downsample path.
+- **Implemented**: Color transform applied only at the source level in both
+  `geotiff2pmtiles` and `pmtransform`. When `FillColor` is set: (1) max-zoom
+  rendered/decoded tiles — transparent pixels → fill before packing; (2) max-zoom
+  positions with no source data → solid fill tile; (3) downsampling — nil children
+  are substituted with fill tiles *before* calling downsample, so the existing
+  downsample code receives 4 tiles and operates normally. No transform in the
+  downsample path.
 
 ## Tile size in resolution calculation
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--resampling`  | `bicubic`     | Interpolation method: `lanczos`, `bicubic`, `bilinear`, `nearest`, `mode` |
 | `--mem-limit`   | auto          | Tile store memory limit in MB before disk spilling (0 = auto ~90% of RAM) |
 | `--no-spill`    | `false`       | Disable disk spilling (keep all tiles in memory)   |
+| `--fill-color`  |               | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` |
 | `--attribution` |               | Attribution string for data sources (stored in metadata) |
 | `--type`        | `baselayer`   | Layer type: `baselayer`, `overlay`                 |
 | `--verbose`     | `false`       | Verbose progress output                            |
@@ -140,6 +141,13 @@ Categorical data (e.g. land cover classification) with mode resampling:
 ```bash
 ./geotiff2pmtiles --format png --resampling mode \
   landcover/ classification.pmtiles
+```
+
+Fill transparent/nodata areas with a solid color:
+
+```bash
+./geotiff2pmtiles --fill-color "0,0,0,255" --format png \
+  data/ output.pmtiles
 ```
 
 Elevation data (auto-detects float GeoTIFF and selects Terrarium encoding):

--- a/changes/2026-02-21-15-00-geotiff2pmtiles-fill-color.md
+++ b/changes/2026-02-21-15-00-geotiff2pmtiles-fill-color.md
@@ -1,0 +1,17 @@
+# Add --fill-color to geotiff2pmtiles
+
+Added `--fill-color` flag to `geotiff2pmtiles`, matching the existing support in
+`pmtransform`. When set, transparent/nodata pixels in rendered tiles are
+substituted with the specified color, empty tile positions within bounds are
+filled with solid-color tiles, and nil-child quadrants during pyramid
+downsampling are replaced with fill tiles.
+
+## Changes
+
+- `internal/tile/generator.go`: Added `FillColor *color.RGBA` to `Config`;
+  applied `applyFillColorTransform` to rendered max-zoom tiles, created uniform
+  fill tiles for empty positions, and substituted nil children during downsampling
+- `cmd/geotiff2pmtiles/main.go`: Added `--fill-color` flag with R,G,B,A and
+  hex color parsing; wired into `tile.Config`, settings summary, and description
+  metadata
+- Updated README.md, ARCHITECTURE.md, DESIGN.md


### PR DESCRIPTION
Mirrors the existing fill-color support from pmtransform: transparent pixels in rendered tiles are replaced with the fill color, empty tile positions get solid fill tiles, and nil children during downsampling are substituted before the downsample kernel runs.