### PR TITLE
Setup CLAUDE.md and Reduce redundancy across documentation files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,8 @@ Update design decisions in DESIGN.md
 Update architecture in ARCHITECTURE.md
 Update the CLI help text
 Update README.md
+
+Each doc has a distinct scope — avoid duplicating content across them:
+- **README.md**: User-facing — what it does, how to install, how to use
+- **ARCHITECTURE.md**: Developer-facing — code structure, pipeline, memory model, extension points
+- **DESIGN.md**: Rationale — why decisions were made, tradeoffs, bug fixes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,13 +83,10 @@ positions within bounds that have no data.
 - LRU tile cache prevents redundant reads (~256 tiles, configurable)
 - Tiles stored as encoded bytes (PNG/WebP/JPEG) in memory: 5-25x smaller than raw pixels
 - Continuous disk spilling via dedicated I/O goroutine with configurable memory backpressure (auto ~90% of RAM)
-- Memory limit accounts for both encoded tile data and Go map overhead (uniform entries, disk index entries) to prevent actual usage from exceeding the configured limit
-- Map pre-allocation sized to the working set (tiles that fit in memory), not the total tile count, avoiding multi-GB upfront waste on empty hash buckets
 - Uniform tiles (single color) stored as 4 bytes, never spilled to disk
-- `sync.Pool` for `*image.RGBA` buffers: render, downsample, and decode paths reuse 256 KB buffers (zeroed on get) instead of allocating/GC'ing per tile
+- `sync.Pool` for `*image.RGBA` buffers: render, downsample, and decode paths reuse 256 KB buffers instead of allocating/GC'ing per tile
 - Single-band nodata pixels decoded as transparent (alpha=0) so resampling/downsampling automatically excludes them
-- Source fallthrough on nodata: transparent (alpha=0) samples are skipped and the next source is tried, preventing holes in one source from blocking valid data in another and eliminating all-transparent tiles from the pyramid
-- Gray tile RGBA expansions (from `AsImage()`) cached in the TileData so `Release()` returns them to the pool
+- Source fallthrough on nodata: transparent (alpha=0) samples are skipped and the next source is tried, preventing holes in one source from blocking valid data in another
 - PMTiles writer uses temp file for tile data (only directory entries in memory)
 - Pyramid downsampling avoids redundant source reads for lower zoom levels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Memory-efficient Go toolset for converting GeoTIFF/COG files to PMTiles v3 archives and transforming existing PMTiles archives. Pure Go stdlib — zero external Go dependencies. Requires libwebp C library for native WebP encoding (`brew install webp` / `apt-get install libwebp-dev`).
+
+## Build & Test Commands
+
+```bash
+make build              # Build geotiff2pmtiles (requires CGO_ENABLED=1 + libwebp)
+make build-transform    # Build pmtransform
+make build-all          # Both binaries
+make test               # Run all tests
+make test-race          # Tests with race detector (used in CI)
+make bench              # Run benchmarks
+make fmt                # gofmt
+make vet                # go vet
+make check              # fmt + vet + test
+```
+
+Run a single test: `go test ./internal/coord/ -run TestMercator`
+
+Run a single benchmark: `go test ./internal/tile/ -bench=BenchmarkDownsample -benchmem`
+
+## Architecture
+
+Two CLI tools in `cmd/`:
+- **geotiff2pmtiles** — COG → PMTiles conversion
+- **pmtransform** — PMTiles → PMTiles transformation (passthrough / re-encode / rebuild pyramid)
+
+Core packages in `internal/`:
+- **cog/** — Memory-mapped TIFF/COG reader, IFD parsing, GeoTIFF tags, TFW sidecar, LRU tile cache, strip-to-tile promotion
+- **coord/** — Projection interface + implementations (Swiss LV95, WGS84, Web Mercator), Hilbert curve ordering, EPSG inference from coordinate ranges
+- **encode/** — Encoder interface + JPEG/PNG/WebP/Terrarium implementations. WebP uses CGo (`webp.go`) with a stub fallback (`webp_stub.go`) for `CGO_ENABLED=0` builds
+- **tile/** — Tile generation pipeline: `generator.go` (parallel COG→tile), `transform.go` (PMTiles→PMTiles), `resample.go` (Lanczos-3/bicubic/bilinear/nearest/mode with LUT acceleration), `downsample.go` (pyramid building with gray fast path), `diskstore.go` (disk-backed store with memory backpressure), `tiledata.go` (compact uniform/gray/RGBA representation), `rgbapool.go` (sync.Pool buffer reuse)
+- **pmtiles/** — PMTiles v3 reader/writer. Two-pass writer: collect entries → sort by Hilbert ID → cluster tile data. FNV-64a deduplication.
+
+**Pipeline flow** (geotiff2pmtiles): Scan COGs → parse metadata → compute bounds/zoom → generate max-zoom tiles (parallel, Hilbert-batched) → inverse-project + resample per pixel → downsample pyramid → encode → two-pass PMTiles write.
+
+**Transform modes** (pmtransform): Passthrough (raw byte copy), re-encode (decode + encode with new format), rebuild (decode max-zoom + downsample new pyramid).
+
+## Key Design Patterns
+
+- **Memory-mapped I/O** for COG access — tile-level reads without loading entire file
+- **Encoded tiles in memory** (5-25x smaller than raw pixels), with disk spilling via dedicated I/O goroutine
+- **LUT-accelerated resampling** — 1024-entry precomputed tables for Lanczos-3 and bicubic kernels
+- **Precomputed lon/lat arrays** — O(n) trig calls instead of O(n²) in Mercator projection
+- **sync.Pool for RGBA buffers** — critical: buffers must be zeroed before reuse
+- **Uniform tile compaction** — single-color tiles stored as 4 bytes
+- **Nodata-aware source fallthrough** — alpha=0 results skipped so later sources can contribute
+
+## After Completing a Task
+
+Per AGENTS.md:
+1. Document changes in `changes/yyyy-mm-dd-hh-mm-title.md`
+2. Update design decisions in `DESIGN.md`
+3. Update architecture in `ARCHITECTURE.md`
+4. Update CLI help text
+5. Update `README.md`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,20 +58,12 @@ A `!cgo` stub (`webp_stub.go`) provides graceful error messages when building wi
 This allows CI cross-compilation without a C toolchain while keeping WebP available for
 native builds.
 
-## Performance profile (2026-02-18, bicubic/WebP/512px, pre-native-libwebp)
+## Performance profile
 
-Profiled with 36 Swiss GeoTIFFs, zoom 12-18, 4 workers. Total: 4690 tiles, 72s wall,
-213s CPU (295% utilization). The two dominant bottlenecks were:
-
-1. **WebP encoding via WASM** (~41% of CPU) — Now replaced by native libwebp via CGo.
-
-2. **Bicubic resampling** (~27% of CPU) — `bicubicAccumYCbCr` is the hot inner loop
-   performing 16 YCbCr→RGB conversions per output pixel. Already optimized with direct
-   array access; the cost is inherent to the kernel size × tile count.
-
-A third cost is the decode-reencode tax for downsampling: tiles encoded as WebP must be
-decoded back to RGBA for the next zoom level, then re-encoded. This adds ~6s CPU and
-17 GB of allocations for the DiskTileStore decode path.
+Pre-native-libwebp profiling identified two dominant bottlenecks: WebP encoding via WASM
+(~41% of CPU, now eliminated by native libwebp via CGo) and bicubic resampling (~27%,
+inherent to kernel size, optimized with LUTs and direct array access). A secondary cost
+is the decode-reencode tax for pyramid downsampling when using lossy formats.
 
 ## Bicubic kernel LUT
 
@@ -97,21 +89,11 @@ next source (see below).
 ## Nodata-aware source fallthrough
 
 `sampleFromTileSources` skips results with alpha=0 and continues to the next source
-instead of returning them as "found". This is critical for two reasons:
-
-1. **Multi-source hole filling**: When source A has nodata at a location but source B
-   has valid data, source A's transparent pixel must not block source B from contributing.
-   Without this check, the first source whose bounding box covers the coordinate "wins"
-   even if it has no actual data there (e.g. empty COG tiles within the raster extent,
-   or pixels matching the GDAL_NODATA value).
-
-2. **Empty tile elimination**: Tiles that fall entirely within a source's bounding box
-   but contain only nodata/transparent pixels are correctly detected as empty
-   (`renderTile` returns nil, `hasData` stays false). This prevents a cascade of
-   falsely non-empty tiles through the entire zoom pyramid during downsampling, and
-   avoids encoding/writing tiles that carry no visible information — especially
-   important for JPEG output which cannot represent transparency (nodata areas would
-   appear as solid black).
+instead of returning them as "found". This prevents nodata in one source from blocking
+valid data in another (multi-source hole filling) and ensures tiles containing only
+nodata are correctly detected as empty rather than cascading falsely non-empty tiles
+through the pyramid — especially important for JPEG output which cannot represent
+transparency.
 
 ## Empty as color transformation (not resampling)
 
@@ -153,42 +135,27 @@ wrong tile size caused 2x too coarse overview selection, producing blurry output
 
 `*image.RGBA` allocations (256 KB each for 256×256 tiles) are pooled via `sync.Pool`
 to reduce GC pressure during tile generation. A `sync.Map` of pools keyed by `(w, h)`
-handles the rare case of multiple tile sizes. `GetRGBA` zeros the pixel buffer with
-`clear()` before returning; `PutRGBA` returns to the pool. Zeroing is critical:
-`renderTile` only writes pixels where source data is found, so unfound pixels must
-be transparent (0,0,0,0) — without clearing, recycled images retain stale pixel
-data from previous tiles, causing visible artifacts at data boundaries. Key recycling
-points:
-- `newTileData`: returns the source RGBA when uniform/gray compaction succeeds
-- `TileData.Release()`: returns internal img after encoding + store in the generator
-- `renderTile`/`renderTileTerrarium`: pool allocation moved after overlap check so
-  empty tiles never allocate; returned on `!hasData` early exit
-- Downsample: destination from pool; child images expanded from gray/uniform tracked
-  with `poolable` flags and returned after the loop (borrowed `TileData.img` pointers
-  are not recycled)
+handles multiple tile sizes. `GetRGBA` zeros the pixel buffer with `clear()` before
+returning; `PutRGBA` returns to the pool. Zeroing is critical: `renderTile` only writes
+pixels where source data is found, so unfound pixels must be transparent (0,0,0,0) —
+without clearing, recycled images retain stale pixel data from previous tiles, causing
+visible artifacts at data boundaries.
 
 ## Disk tile store memory accounting
 
-The disk tile store tracks memory usage to enforce the configured limit. Two key insights
-that required fixes:
+The disk tile store tracks memory usage to enforce the configured limit. Three fixes:
 
-**Map pre-allocation**: When creating the store for zoom 20 with 112M tiles, Go maps were
-pre-allocated with `make(map[K]V, 112M)`. Each map bucket is ~400 bytes (8 entries × key
-+ value + metadata), so a 112M-hint `encoded` map alone pre-allocated ~13.4 GB of empty
-hash buckets. Combined with the `uniforms` map (~2.3 GB), this was ~16 GB of waste at
-creation time, before any tiles were stored. Fixed by capping pre-allocation to the
-number of tiles that actually fit in the memory limit (~600K for 12 GB at 20 KB/tile).
+**Map pre-allocation**: Go map hints sized to the total tile count (e.g. 112M) waste
+gigabytes on empty hash buckets. Fixed by capping pre-allocation to the working set
+(tiles that fit in the memory limit).
 
-**Map overhead tracking**: The memory counter (`memBytes`) only tracked encoded byte slice
-lengths (and 4 bytes per uniform tile), completely ignoring Go map entry overhead: ~128
-bytes per uniform entry (key + pointer + TileData struct + bucket metadata) and ~64 bytes
-per disk index entry. Over 112M tiles, the `index` map alone uses ~7 GB untracked. Added
-a separate `mapOverhead` counter that includes these estimates and is included in the
-memory limit check.
+**Map overhead tracking**: The memory counter only tracked encoded byte slices, ignoring
+Go map entry overhead (~128 bytes/uniform entry, ~64 bytes/disk index entry). Added a
+`mapOverhead` counter included in the memory limit check.
 
-**Gray tile RGBA leak**: `AsImage()` for gray tiles called `ToRGBA()` which allocated a
-256 KB RGBA via `GetRGBA()` that was never returned to the pool. Fixed by caching the
-expanded image in `t.img` so that `Release()` returns it.
+**Gray tile RGBA leak**: `AsImage()` for gray tiles allocated an RGBA buffer via
+`GetRGBA()` that was never returned to the pool. Fixed by caching the expanded image
+in `t.img` so that `Release()` returns it.
 
 ## Mode (most common value) resampling
 

--- a/README.md
+++ b/README.md
@@ -247,36 +247,10 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full project structure, pipeline 
 
 ## Performance
 
-The render pipeline has been profiled and optimized for throughput across multiple rounds.
-
-### Lanczos-3 resampling optimization
-
-Workload: 4690 tiles (36 Swiss LV95 COGs, z12-18, 512px WebP q85, concurrency 4):
-
-| Optimization | Technique | Reduction |
-| --- | --- | --- |
-| Batched tile fetches | 6×6 kernel spans at most 4 tiles; fetch each once instead of 36 cache lookups per pixel | 58x cache lookup reduction |
-| Lanczos kernel LUT | 1024-entry precomputed table with linear interpolation replaces 12 `math.Sin` calls per pixel | 16x kernel eval reduction |
-| Bicubic kernel LUT | 1024-entry precomputed table with linear interpolation replaces polynomial evaluation per pixel | Eliminates cubic polynomial overhead |
-| YCbCr fast path | Single type assertion when all 36 pixels fall in one tile; inline YCbCr→RGB conversion | 33x pixel extraction reduction |
-
-**Result**: 4.7x wall-time speedup (7m15s to 1m32s), 5.2x CPU reduction. Final profile is balanced across YCbCr accumulation (29%), Lanczos sampling (44% cumulative), and downsampling (8%).
-
-### Earlier pipeline optimizations
-
-Measured impact (36 Swiss LV95 COGs, z10-16, 512px WebP, Apple M-series):
-
-| Optimization | Technique | CPU reduction |
-| --- | --- | --- |
-| Precompute lon/lat | Web Mercator lon is linear with px, lat depends only on py; precompute per-row/col instead of per-pixel trig (Atan, Sinh) | O(n^2) -> O(n) trig calls |
-| Tile-level pixel extraction | `pixelFromImage` type-switch (YCbCr, RGBA) avoids `image.At()` interface boxing and `Point.In` bounds checks | ~18% of baseline eliminated |
-| Bilinear tile reuse | `fetchTileCached` fetches 1-2 tiles instead of 4 per-pixel cache lookups for bilinear interpolation | ~35% of baseline eliminated |
-| RWMutex tile cache | `sync.RWMutex` on cache shards allows concurrent readers | 82% reduction in cache lock time |
-| Bit-shift pow2 | `pow2(z)` via bit shift replaces `math.Pow(2, float64(z))` in all Mercator functions | ~4% of baseline eliminated |
-| Package-level clampByte | Moved out of closure so the compiler can inline it | Enables inlining |
-| Direct Pix writes | Write to `img.Pix[]` directly instead of `img.SetRGBA()` | Eliminates bounds checks |
-
-**Result**: ~24% wall-time speedup (8.1s to 6.3s median), 43% CPU reduction, with byte-identical output (verified via SHA-256).
+The pipeline is profiled and optimized for throughput. Key techniques: LUT-accelerated
+resampling (precomputed Lanczos-3 and bicubic kernel tables), batched tile fetches to
+minimize cache lookups, native libwebp encoding via CGo, precomputed lon/lat arrays for
+O(n) Mercator projection, direct pixel buffer writes, and YCbCr fast paths.
 
 ### Profiling
 

--- a/changes/2026-02-26-doc-cleanup.md
+++ b/changes/2026-02-26-doc-cleanup.md
@@ -1,0 +1,17 @@
+# Documentation cleanup: reduce redundancy across docs
+
+Trimmed overlapping and verbose content across ARCHITECTURE.md, README.md, and DESIGN.md
+to give each file a clear, non-overlapping purpose:
+
+- **ARCHITECTURE.md**: Removed implementation-level memory bullets (map pre-allocation
+  sizing, map overhead tracking, gray tile RGBA leak) that duplicate DESIGN.md entries.
+  Trimmed sync.Pool bullet to architectural level.
+
+- **README.md**: Replaced two detailed optimization tables (~30 lines of per-technique
+  measurements) with a brief summary paragraph. Kept profiling commands.
+
+- **DESIGN.md**: Condensed four verbose entries:
+  - Performance profile: removed date-specific numbers, kept key insights
+  - Disk tile store accounting: trimmed worked example, kept the three fixes
+  - sync.Pool: removed recycling points list, kept the pattern and zeroing rationale
+  - Nodata fallthrough: consolidated two numbered sub-points into one paragraph


### PR DESCRIPTION
Setup CLAUDE.md.

Trim implementation details from ARCHITECTURE.md that duplicate DESIGN.md, replace verbose optimization tables in README.md with a summary, condense wordy DESIGN.md entries, and add doc scoping guidelines to AGENTS.md.
