### PR TITLE
Add RGBNIR/uint16 GeoTIFF support with preset auto-detection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,8 +8,8 @@ cmd/
   debug/main.go                     Low-level COG debug utility
 internal/
   cog/
-    reader.go                       COG/GeoTIFF tile-level reader (memory-mapped, nodata-aware, 8/16-bit, band reorder/rescale)
-    ifd.go                          TIFF IFD parser
+    reader.go                       COG/GeoTIFF tile-level reader (memory-mapped, nodata-aware, 8/16-bit, band reorder/rescale, preset auto-detection)
+    ifd.go                          TIFF IFD parser (incl. GDAL_METADATA XML tag 42112)
     geotags.go                      GeoTIFF metadata extraction
     tfw.go                          TFW (TIFF World File) parser + EPSG inference
     tilecache.go                    LRU tile cache for decoded source tiles

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ cmd/
   debug/main.go                     Low-level COG debug utility
 internal/
   cog/
-    reader.go                       COG/GeoTIFF tile-level reader (memory-mapped, nodata-aware)
+    reader.go                       COG/GeoTIFF tile-level reader (memory-mapped, nodata-aware, 8/16-bit, band reorder/rescale)
     ifd.go                          TIFF IFD parser
     geotags.go                      GeoTIFF metadata extraction
     tfw.go                          TFW (TIFF World File) parser + EPSG inference

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -203,6 +203,34 @@ same row. After decompression, the predictor is reversed by accumulating the del
 row-by-row. This applies to both tile-based and strip-based reads. Without this step,
 pixel values are raw deltas, producing garbled imagery.
 
+For 16-bit data (bytesPerSample=2), deltas are uint16 values that must be read and
+written using the TIFF byte order rather than single-byte accumulation. The function
+accepts `bytesPerSample` and `binary.ByteOrder` to dispatch between 8-bit and 16-bit
+paths.
+
+## BandConfig: band reordering, alpha, and rescaling
+
+Multi-band GeoTIFFs (e.g. 4-band RGBNIR uint16) need band selection, alpha handling,
+and value rescaling to produce usable 8-bit RGBA output. `BandConfig` is set once
+after `OpenAll()` and before tile generation — it's immutable during concurrent reads.
+
+**Band reordering**: `Bands [3]int` maps 1-indexed input bands to R,G,B output channels.
+For false-color composites, `--bands 4,1,2` maps NIR→R, R→G, G→B. Zero values default
+to `1,2,3`.
+
+**Alpha band**: `AlphaBand` controls transparency. `0` = auto (band 4 for 8-bit spp≥4,
+none for 16-bit), `-1` = force no alpha, `>0` = explicit 1-indexed band. When an alpha
+band is configured and the source value is 0, the pixel is fully transparent.
+
+**Rescaling**: `buildRescaler` returns a `func(uint16) uint8` closure. Linear mode maps
+`[min,max] → [0,255]` proportionally. Log mode uses `ln(1 + v - min) / ln(1 + max - min)`
+for better dynamic range in data with large value spans (e.g. satellite reflectance).
+Auto mode selects linear 0-65535 for 16-bit data, none for 8-bit.
+
+**Backwards compatibility**: Zero-value `BandConfig` activates the legacy code path for
+8-bit data, including nodata handling for spp≤2. No behavioral change for existing
+8-bit workflows.
+
 ## Description metadata provenance
 
 PMTiles archives record processing provenance in the `description` field of the metadata

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -272,3 +272,45 @@ size by reading and decoding one tile from the max zoom level and using its imag
 dimensions. If no tile can be decoded (e.g. all empty), it falls back to 256. This
 ensures 512px archives stay 512px when rebuilding with `--resampling lanczos` instead
 of inadvertently reducing to 256.
+
+## Preset auto-detection
+
+`DetectPreset()` examines the GeoTIFF structure and GDAL metadata (tag 42112) to
+auto-configure processing. It returns a `Preset` with a name, optional format
+override, and optional `BandConfig`.
+
+**Float detection**: If the sample format is IEEE floating point (SampleFormat=3),
+returns the `float-terrarium` preset with `Format: "terrarium"`. The CLI applies
+this format override when using the default format (jpeg), replacing the previous
+inline float detection logic.
+
+**GDAL_METADATA parsing**: TIFF tag 42112 contains an XML blob with `<Item>` elements.
+Items have a `name` attribute and optional `sample` (0-indexed band) and `role`
+attributes. The XML is parsed into `GDALMeta` with two levels: `Items` (dataset-level)
+and `BandItems` (per-band, keyed by sample index).
+
+**Multi-band detection** auto-configures band mapping and rescaling from two sources of
+band descriptions:
+
+1. **Per-band DESCRIPTION items** — `<Item name="DESCRIPTION" sample="N">` values
+   containing color role keywords (red, green, blue, nir, near-infrared, infrared).
+   This is the GDAL standard and works with any GDAL-created multi-band GeoTIFF:
+   Google Earth Engine exports, PlanetScope, HLS, gdal_translate output, etc.
+
+2. **Dataset-level "bands" string** — fallback for files that use a `bands` item
+   containing `"Band N: BXX (Role)"` entries (e.g. ESA WorldCover composites).
+   Roles are matched through the same keyword table as per-band DESCRIPTION items.
+
+Strategy 1 is tried first; if it finds Red+Green+Blue, detection succeeds. Otherwise
+strategy 2 is attempted. This avoids any product-specific hardcoding — detection is
+purely driven by the band descriptions present in the GeoTIFF.
+
+Scale/offset detection checks per-band `SCALE`/`OFFSET` items first (sample 0), then
+falls back to dataset-level items. The rescale range is derived as `[min, max]` where
+`max = round(1/scale)` and `min = round(-offset/scale)` when offset is negative (e.g.
+Landsat Collection 2: scale=0.0000275, offset=-0.2 → range [7273, 36364]). When no
+scale is found, defaults to 0-10000 (the most common reflectance quantification).
+
+The CLI tries auto-detection in `parseBandConfig` only when `--rescale auto` (default),
+16-bit data, no explicit `--rescale-range`, and no explicit `--bands` override. Explicit
+flags always take precedence.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ A second sample directory `data_tfw/` supports plain TIFFs with TFW sidecar file
 - Plain TIFF with TFW (TIFF World File) sidecar for georeferencing
 - Strip-based and tiled TIFF layouts
 - TIFF compression: JPEG, LZW, Deflate/Zlib, and uncompressed (with predictor support)
-- Sample formats: 8-bit RGB/RGBA, Float32/Float64 (for elevation/DEM data)
+- Sample formats: 8-bit RGB/RGBA, 16-bit uint16 (with linear/log rescaling), Float32/Float64 (for elevation/DEM data)
+- Band reordering and alpha band selection for multi-band GeoTIFFs (e.g. RGBNIR false-color composites)
 - Source CRS: EPSG:2056 (Swiss LV95), EPSG:4326 (WGS84), EPSG:3857 (Web Mercator)
 - Extensible projection interface for adding additional CRS support
 
@@ -109,6 +110,10 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--fill-color`  |               | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` |
 | `--attribution` |               | Attribution string for data sources (stored in metadata) |
 | `--type`        | `baselayer`   | Layer type: `baselayer`, `overlay`                 |
+| `--bands`       | `1,2,3`       | 1-indexed band numbers for R,G,B output (e.g. `4,1,2` for NIR-R-G false color) |
+| `--alpha-band`  | `auto`        | Alpha band: `auto` (band 4 for 8-bit spp>=4), `-1` (none), or 1-indexed band |
+| `--rescale`     | `auto`        | Rescale mode: `auto` (linear for 16-bit), `linear`, `log`, `none` |
+| `--rescale-range` |             | Input value range `min,max` for rescaling (required when `--rescale` is explicit) |
 | `--verbose`     | `false`       | Verbose progress output                            |
 | `--version`     |               | Print version and exit                             |
 | `--cpuprofile`  |               | Write CPU profile to file                          |
@@ -154,6 +159,20 @@ Elevation data (auto-detects float GeoTIFF and selects Terrarium encoding):
 
 ```bash
 ./geotiff2pmtiles --verbose dem/ elevation.pmtiles
+```
+
+RGBNIR satellite data with log rescaling and NIR as alpha:
+
+```bash
+./geotiff2pmtiles --bands 1,2,3 --alpha-band 4 --rescale log \
+  --rescale-range 1,10000 --format png data2/ rgbnir.pmtiles
+```
+
+RGBNIR false-color composite (NIR-R-G):
+
+```bash
+./geotiff2pmtiles --bands 4,1,2 --alpha-band -1 --rescale linear \
+  --rescale-range 0,8000 --format webp data2/ falsecolor.pmtiles
 ```
 
 Convert a plain TIFF with TFW world file (global Natural Earth data):

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A second sample directory `data_tfw/` supports plain TIFFs with TFW sidecar file
 - **Native WebP**: WebP encoding/decoding via native libwebp (CGo), eliminating WASM overhead for 3-5x faster encodes
 - **Multiple encodings**: JPEG, PNG, WebP, and Terrarium (for elevation/DEM data)
 - **Auto zoom detection**: Calculates maximum zoom level from source resolution
-- **Auto float detection**: Automatically selects Terrarium encoding for float GeoTIFF input (elevation data)
+- **Auto-detection**: Automatically detects data type and configures processing — float GeoTIFFs get Terrarium encoding for elevation/DEM data; multi-band satellite GeoTIFFs with GDAL band descriptions get automatic band ordering and rescale range. Works with Sentinel-2, PlanetScope, Google Earth Engine exports, HLS, and any GDAL-created multi-band GeoTIFF — no manual flags needed
 - **Coverage gap detection**: Warns about geographic holes in input file coverage
 - **Parallel processing**: Concurrent tile generation with configurable worker pool and Hilbert-curve batch scheduling for spatial locality
 - **PMTiles v3**: Writes spec-compliant archives with Hilbert-curve tile ordering
@@ -161,6 +161,13 @@ Elevation data (auto-detects float GeoTIFF and selects Terrarium encoding):
 ./geotiff2pmtiles --verbose dem/ elevation.pmtiles
 ```
 
+Multi-band satellite data (auto-detected — no band/rescale flags needed):
+
+```bash
+./geotiff2pmtiles --format png data2/ rgbnir.pmtiles
+# Auto-detected: multispectral-rgbnir (bands 1,2,3, rescale linear [0, 10000])
+```
+
 RGBNIR satellite data with log rescaling and NIR as alpha:
 
 ```bash
@@ -173,6 +180,13 @@ RGBNIR false-color composite (NIR-R-G):
 ```bash
 ./geotiff2pmtiles --bands 4,1,2 --alpha-band -1 --rescale linear \
   --rescale-range 0,8000 --format webp data2/ falsecolor.pmtiles
+```
+
+NIR as alpha (vegetation opaque, water/urban transparent — useful as overlay):
+
+```bash
+./geotiff2pmtiles --alpha-band 4 --rescale linear \
+  --rescale-range 0,10000 --format png --type overlay data2/ nir-alpha.pmtiles
 ```
 
 Convert a plain TIFF with TFW world file (global Natural Earth data):

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--type`        | `baselayer`   | Layer type: `baselayer`, `overlay`                 |
 | `--bands`       | `1,2,3`       | 1-indexed band numbers for R,G,B output (e.g. `4,1,2` for NIR-R-G false color) |
 | `--alpha-band`  | `auto`        | Alpha band: `auto` (band 4 for 8-bit spp>=4), `-1` (none), or 1-indexed band |
-| `--rescale`     | `auto`        | Rescale mode: `auto` (linear for 16-bit), `linear`, `log`, `none` |
-| `--rescale-range` |             | Input value range `min,max` for rescaling (required when `--rescale` is explicit) |
+| `--rescale`     | `auto`        | Rescale mode: `auto`, `linear`, `log`, `none` (auto requires `--rescale-range` for 16-bit) |
+| `--rescale-range` |             | Input value range `min,max` for rescaling (required for 16-bit data) |
 | `--verbose`     | `false`       | Verbose progress output                            |
 | `--version`     |               | Print version and exit                             |
 | `--cpuprofile`  |               | Write CPU profile to file                          |

--- a/changes/2026-02-26-rgbnir-uint16-support.md
+++ b/changes/2026-02-26-rgbnir-uint16-support.md
@@ -1,0 +1,40 @@
+# RGBNIR / uint16 GeoTIFF Support
+
+## Summary
+
+Added support for 16-bit (uint16) GeoTIFF files with band reordering, alpha band
+selection, and configurable rescaling (linear/logarithmic) from uint16 to uint8.
+
+## Changes
+
+### Bug fix: 16-bit horizontal differencing predictor
+- `undoHorizontalDifferencing` now accepts `bytesPerSample` and `binary.ByteOrder`
+  parameters, correctly handling uint16 delta accumulation for predictor=2 with
+  16-bit data. Previously read 1 byte per sample, garbling 16-bit deflate+predictor
+  compressed files (e.g. ESA WorldCover S2 RGBNIR).
+
+### New: BandConfig and rescaling
+- `BandConfig` struct controls band selection (`Bands [3]int`), alpha band
+  (`AlphaBand int`), and rescaling mode/range.
+- `buildRescaler` returns a `func(uint16) uint8` for None/Linear/Log modes.
+- `decodeRawTile` rewritten to handle both 8-bit and 16-bit samples, with band
+  reordering, configurable alpha, and rescaling. Zero-value BandConfig preserves
+  exact legacy behavior for 8-bit data.
+
+### New CLI flags (geotiff2pmtiles)
+- `--bands`: 1-indexed band numbers for R,G,B output (default: `1,2,3`)
+- `--alpha-band`: Alpha band selection (`auto`, `-1`=none, or 1-indexed band)
+- `--rescale`: Rescale mode (`auto`, `linear`, `log`, `none`)
+- `--rescale-range`: Input value range `min,max` (required when --rescale is explicit)
+
+### New accessors
+- `Reader.SetBandConfig(cfg BandConfig)` — set config after open, before reading
+- `Reader.BitsPerSample() int` — bits per sample of first IFD
+- `Reader.SamplesPerPixel() int` — samples per pixel of first IFD
+
+## Files modified
+- `internal/cog/reader.go` — core changes
+- `internal/cog/ifd.go` — `bytesPerSample()` method
+- `internal/cog/reader_test.go` — new test file with 15 tests
+- `cmd/geotiff2pmtiles/main.go` — CLI flags, band config parsing
+- `DESIGN.md`, `ARCHITECTURE.md`, `README.md` — documentation

--- a/changes/2026-02-26-sentinel2-auto-detect.md
+++ b/changes/2026-02-26-sentinel2-auto-detect.md
@@ -1,0 +1,32 @@
+# Satellite Data Auto-Detection from GDAL Metadata
+
+Auto-detect band ordering and rescale range from GDAL_METADATA XML (tag 42112) so that
+multi-band satellite GeoTIFFs work without manual `--bands` or `--rescale-range` flags.
+Detection is generic — no product-specific presets. Works with any GDAL-created
+multi-band GeoTIFF that has band descriptions (per-band DESCRIPTION items or a
+dataset-level "bands" string with "Band N: BXX (Role)" format).
+
+## Changes
+
+- **cog/ifd.go**: Parse GDAL_METADATA XML tag (42112) into `GDALMeta` struct with
+  two levels: `Items` (dataset-level) and `BandItems` (per-band, keyed by 0-indexed
+  sample). Preserves the `sample` attribute needed for per-band DESCRIPTION/SCALE/OFFSET.
+
+- **cog/reader.go**: Add `Preset` struct, `DetectPreset()` method, and `GDALMeta()`
+  accessor. Band role detection from two sources:
+  1. Per-band DESCRIPTION items — matches keywords (red, green, blue, nir, etc.)
+  2. Dataset-level "bands" string — parses "Band N: BXX (Role)" entries
+  Scale/offset: per-band SCALE/OFFSET → dataset-level → default 0-10000.
+  Offset support for Landsat-style negative offsets.
+
+- **cmd/geotiff2pmtiles/main.go**: In `parseBandConfig`, when `--rescale auto`
+  and 16-bit data with no explicit `--rescale-range`, try `DetectPreset()` before
+  erroring. Explicit flags always override.
+
+- **cmd/coginfo/main.go**: Display GDAL metadata (dataset-level and per-band items)
+  and detected preset.
+
+- **cog/reader_test.go**: Tests for XML parsing (dataset-level, per-band, empty),
+  band detection from "bands" string (standard and reordered), GDAL-standard
+  DESCRIPTION (RGBNIR, RGB-only), Landsat-style offset, negative cases, and
+  validation against the actual ESA WorldCover S2 RGBNIR file.

--- a/changes/2026-02-27-preset-auto-detect.md
+++ b/changes/2026-02-27-preset-auto-detect.md
@@ -1,0 +1,23 @@
+# Unified Preset Auto-Detection
+
+Consolidate float/terrarium and multi-band satellite detection into a single
+`DetectPreset()` method. The `Preset` struct now carries an optional `Format` field
+(e.g. "terrarium") in addition to `BandCfg`.
+
+## Changes
+
+- **cog/reader.go**: `Preset` gains `Format string` field. `DetectPreset()` checks
+  float data first (returns `float-terrarium` preset with `Format: "terrarium"`),
+  then multi-band GDAL metadata detection. Removed separate `detectSentinel2()`
+  method — band detection is purely generic via per-band DESCRIPTION items and
+  dataset-level "bands" strings.
+
+- **cmd/geotiff2pmtiles/main.go**: Replaced inline float detection with preset-based
+  flow. `DetectPreset()` is called once before `parseBandConfig`; if the preset has
+  a format override and the current format is the default (jpeg), the format is
+  switched. The terrarium validation check remains.
+
+- **cmd/coginfo/main.go**: Show `Format` field when present in detected preset.
+  Only show band/rescale info when rescaling is configured.
+
+- **cog/reader_test.go**: Added `TestDetectPresetFloatTerrarium` for float32 data.

--- a/cmd/coginfo/main.go
+++ b/cmd/coginfo/main.go
@@ -33,6 +33,31 @@ func main() {
 	minX, minY, maxX, maxY := r.BoundsInCRS()
 	fmt.Printf("Bounds (CRS): X=[%f, %f], Y=[%f, %f]\n", minX, maxX, minY, maxY)
 
+	// Print GDAL metadata if present.
+	if md := r.GDALMeta(); md != nil {
+		fmt.Printf("\nGDAL Metadata:\n")
+		for k, v := range md.Items {
+			fmt.Printf("  %s: %s\n", k, v)
+		}
+		for sample, items := range md.BandItems {
+			for k, v := range items {
+				fmt.Printf("  [band %d] %s: %s\n", sample, k, v)
+			}
+		}
+	}
+
+	// Print auto-detected preset if available.
+	if preset, ok := r.DetectPreset(); ok {
+		fmt.Printf("\nDetected preset: %s\n", preset.Name)
+		if preset.Format != "" {
+			fmt.Printf("  Format: %s\n", preset.Format)
+		}
+		if preset.BandCfg.Rescale != cog.RescaleNone {
+			fmt.Printf("  Bands: %d,%d,%d\n", preset.BandCfg.Bands[0], preset.BandCfg.Bands[1], preset.BandCfg.Bands[2])
+			fmt.Printf("  Rescale: linear [%.0f, %.0f]\n", preset.BandCfg.RescaleMin, preset.BandCfg.RescaleMax)
+		}
+	}
+
 	// Try reading a tile at each IFD level to check compression support
 	for level := 0; level < r.IFDCount(); level++ {
 		ts := r.IFDTileSize(level)

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -70,8 +70,8 @@ func main() {
 	flag.StringVar(&layerType, "type", "baselayer", "Layer type: baselayer, overlay")
 	flag.StringVar(&bandsStr, "bands", "1,2,3", "1-indexed band numbers for R,G,B output (e.g. \"4,1,2\" for NIR-R-G)")
 	flag.StringVar(&alphaBandStr, "alpha-band", "auto", "1-indexed band for alpha (0=auto: band 4 for 8-bit spp>=4; -1=force no alpha)")
-	flag.StringVar(&rescaleStr, "rescale", "auto", "Rescale mode: auto, log, linear (auto: linear for 16-bit, none for 8-bit)")
-	flag.StringVar(&rescaleRange, "rescale-range", "", "Input value range for rescaling: min,max (required when --rescale is explicit)")
+	flag.StringVar(&rescaleStr, "rescale", "auto", "Rescale mode: auto, log, linear, none (auto: requires --rescale-range for 16-bit)")
+	flag.StringVar(&rescaleRange, "rescale-range", "", "Input value range for rescaling: min,max (required for 16-bit data)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>\n\n")
@@ -551,17 +551,18 @@ func parseBandConfig(bandsStr, alphaBandStr, rescaleStr, rescaleRange string, fi
 	switch rescaleStr {
 	case "auto":
 		if is16 {
-			cfg.Rescale = cog.RescaleLinear
-			cfg.RescaleMin = 0
-			cfg.RescaleMax = 65535
-			if rescaleRange != "" {
-				minV, maxV, err := parseRange(rescaleRange)
-				if err != nil {
-					return cfg, fmt.Errorf("--rescale-range: %w", err)
-				}
-				cfg.RescaleMin = minV
-				cfg.RescaleMax = maxV
+			if rescaleRange == "" {
+				return cfg, fmt.Errorf("16-bit GeoTIFF detected: --rescale-range min,max is required\n" +
+					"  Hint: use gdalinfo or inspect the data to find the value range.\n" +
+					"  Example: --rescale linear --rescale-range 0,5000")
 			}
+			cfg.Rescale = cog.RescaleLinear
+			minV, maxV, err := parseRange(rescaleRange)
+			if err != nil {
+				return cfg, fmt.Errorf("--rescale-range: %w", err)
+			}
+			cfg.RescaleMin = minV
+			cfg.RescaleMax = maxV
 		} else {
 			cfg.Rescale = cog.RescaleNone
 		}

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -194,6 +194,25 @@ func main() {
 		}
 	}
 
+	// Auto-detect preset from GeoTIFF structure and GDAL metadata.
+	// Apply format override (e.g. terrarium for float data) before band config
+	// parsing so that the format is settled before we proceed.
+	if preset, ok := sources[0].DetectPreset(); ok {
+		if preset.Format != "" && format == "jpeg" {
+			format = preset.Format
+			log.Printf("Auto-detected: %s (format: %s)", preset.Name, format)
+			enc, err = encode.NewEncoder(format, quality)
+			if err != nil {
+				log.Fatalf("Encoder: %v", err)
+			}
+		}
+	}
+
+	// Validate terrarium requires float input.
+	if format == "terrarium" && !sources[0].IsFloat() {
+		log.Fatal("Terrarium format requires float GeoTIFF input (elevation data)")
+	}
+
 	// Parse band config.
 	bandCfg, err := parseBandConfig(bandsStr, alphaBandStr, rescaleStr, rescaleRange, sources[0])
 	if err != nil {
@@ -201,26 +220,6 @@ func main() {
 	}
 	for _, src := range sources {
 		src.SetBandConfig(bandCfg)
-	}
-
-	// Auto-detect float GeoTIFFs and suggest terrarium format.
-	isFloat := sources[0].IsFloat()
-	if isFloat {
-		if verbose {
-			log.Printf("Detected float GeoTIFF data (elevation/DEM)")
-		}
-		if format == "jpeg" {
-			// Auto-switch to terrarium for float data when using the default format.
-			format = "terrarium"
-			log.Printf("Auto-selected terrarium encoding for float GeoTIFF data")
-			enc, err = encode.NewEncoder(format, quality)
-			if err != nil {
-				log.Fatalf("Encoder: %v", err)
-			}
-		}
-	}
-	if format == "terrarium" && !isFloat {
-		log.Fatal("Terrarium format requires float GeoTIFF input (elevation data)")
 	}
 
 	// Compute merged bounds in WGS84.
@@ -548,10 +547,19 @@ func parseBandConfig(bandsStr, alphaBandStr, rescaleStr, rescaleRange string, fi
 
 	// Parse --rescale and --rescale-range.
 	is16 := firstSrc.BitsPerSample() == 16
+	bandsExplicit := bandsStr != "1,2,3"
 	switch rescaleStr {
 	case "auto":
 		if is16 {
 			if rescaleRange == "" {
+				// Try auto-detection from GDAL metadata before erroring.
+				if preset, ok := firstSrc.DetectPreset(); ok && !bandsExplicit {
+					log.Printf("Auto-detected: %s (bands %d,%d,%d, rescale linear [%.0f, %.0f])",
+						preset.Name,
+						preset.BandCfg.Bands[0], preset.BandCfg.Bands[1], preset.BandCfg.Bands[2],
+						preset.BandCfg.RescaleMin, preset.BandCfg.RescaleMax)
+					return preset.BandCfg, nil
+				}
 				return cfg, fmt.Errorf("16-bit GeoTIFF detected: --rescale-range min,max is required\n" +
 					"  Hint: use gdalinfo or inspect the data to find the value range.\n" +
 					"  Example: --rescale linear --rescale-range 0,5000")

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -30,22 +30,26 @@ var (
 
 func main() {
 	var (
-		format      string
-		quality     int
-		minZoom     int
-		maxZoom     int
-		showVersion bool
-		tileSize    int
-		concurrency int
-		verbose     bool
-		resampling  string
-		cpuProfile  string
-		memProfile  string
-		memLimitMB  int
-		noSpill     bool
-		fillColor   string
-		attribution string
-		layerType   string
+		format       string
+		quality      int
+		minZoom      int
+		maxZoom      int
+		showVersion  bool
+		tileSize     int
+		concurrency  int
+		verbose      bool
+		resampling   string
+		cpuProfile   string
+		memProfile   string
+		memLimitMB   int
+		noSpill      bool
+		fillColor    string
+		attribution  string
+		layerType    string
+		bandsStr     string
+		alphaBandStr string
+		rescaleStr   string
+		rescaleRange string
 	)
 
 	flag.StringVar(&format, "format", "jpeg", "Tile encoding: jpeg, png, webp, terrarium")
@@ -64,6 +68,10 @@ func main() {
 	flag.StringVar(&fillColor, "fill-color", "", "Substitute transparent/nodata with RGBA (color transform); also fill missing tile positions, e.g. \"0,0,0,255\" or \"#000000ff\"")
 	flag.StringVar(&attribution, "attribution", "", "Attribution string for data sources (stored in metadata)")
 	flag.StringVar(&layerType, "type", "baselayer", "Layer type: baselayer, overlay")
+	flag.StringVar(&bandsStr, "bands", "1,2,3", "1-indexed band numbers for R,G,B output (e.g. \"4,1,2\" for NIR-R-G)")
+	flag.StringVar(&alphaBandStr, "alpha-band", "auto", "1-indexed band for alpha (0=auto: band 4 for 8-bit spp>=4; -1=force no alpha)")
+	flag.StringVar(&rescaleStr, "rescale", "auto", "Rescale mode: auto, log, linear (auto: linear for 16-bit, none for 8-bit)")
+	flag.StringVar(&rescaleRange, "rescale-range", "", "Input value range for rescaling: min,max (required when --rescale is explicit)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>\n\n")
@@ -186,6 +194,15 @@ func main() {
 		}
 	}
 
+	// Parse band config.
+	bandCfg, err := parseBandConfig(bandsStr, alphaBandStr, rescaleStr, rescaleRange, sources[0])
+	if err != nil {
+		log.Fatalf("Band config: %v", err)
+	}
+	for _, src := range sources {
+		src.SetBandConfig(bandCfg)
+	}
+
 	// Auto-detect float GeoTIFFs and suggest terrarium format.
 	isFloat := sources[0].IsFloat()
 	if isFloat {
@@ -260,6 +277,23 @@ func main() {
 	} else {
 		fmt.Printf("  %-14s auto (~90%% of RAM)\n", "Mem limit:")
 	}
+	if bandCfg.Bands != ([3]int{1, 2, 3}) || bandCfg.AlphaBand != 0 || bandCfg.Rescale != cog.RescaleNone {
+		fmt.Printf("  %-14s %d,%d,%d\n", "Bands:", bandCfg.Bands[0], bandCfg.Bands[1], bandCfg.Bands[2])
+		switch bandCfg.AlphaBand {
+		case 0:
+			fmt.Printf("  %-14s auto\n", "Alpha band:")
+		case -1:
+			fmt.Printf("  %-14s none\n", "Alpha band:")
+		default:
+			fmt.Printf("  %-14s %d\n", "Alpha band:", bandCfg.AlphaBand)
+		}
+		switch bandCfg.Rescale {
+		case cog.RescaleLinear:
+			fmt.Printf("  %-14s linear [%.0f, %.0f]\n", "Rescale:", bandCfg.RescaleMin, bandCfg.RescaleMax)
+		case cog.RescaleLog:
+			fmt.Printf("  %-14s log [%.0f, %.0f]\n", "Rescale:", bandCfg.RescaleMin, bandCfg.RescaleMax)
+		}
+	}
 	fmt.Printf("  %-14s %d file(s)\n", "Input:", len(tiffFiles))
 	fmt.Printf("  %-14s %s\n", "Output:", outputPath)
 
@@ -281,7 +315,7 @@ func main() {
 	}
 
 	// Build description for PMTiles metadata.
-	description := buildDescription(sources, mergedBounds, gaps, format, quality, tileSize, minZoom, maxZoom, resampling, fc)
+	description := buildDescription(sources, mergedBounds, gaps, format, quality, tileSize, minZoom, maxZoom, resampling, fc, bandCfg)
 
 	// Create PMTiles writer.
 	writer, err := pmtiles.NewWriter(outputPath, pmtiles.WriterOptions{
@@ -354,7 +388,7 @@ func isTIFF(name string) bool {
 }
 
 func buildDescription(sources []*cog.Reader, mergedBounds cog.Bounds, gaps []cog.CoverageGap,
-	format string, quality int, tileSize int, minZoom, maxZoom int, resampling string, fc *color.RGBA) string {
+	format string, quality int, tileSize int, minZoom, maxZoom int, resampling string, fc *color.RGBA, bandCfg cog.BandConfig) string {
 
 	var b strings.Builder
 
@@ -370,6 +404,23 @@ func buildDescription(sources []*cog.Reader, mergedBounds cog.Bounds, gaps []cog
 	b.WriteString(fmt.Sprintf("  Resampling: %s\n", resampling))
 	if fc != nil {
 		b.WriteString(fmt.Sprintf("  Fill color: rgba(%d,%d,%d,%d)\n", fc.R, fc.G, fc.B, fc.A))
+	}
+	if bandCfg.Bands != ([3]int{1, 2, 3}) || bandCfg.AlphaBand != 0 || bandCfg.Rescale != cog.RescaleNone {
+		b.WriteString(fmt.Sprintf("  Bands: %d,%d,%d\n", bandCfg.Bands[0], bandCfg.Bands[1], bandCfg.Bands[2]))
+		switch bandCfg.AlphaBand {
+		case 0:
+			b.WriteString("  Alpha band: auto\n")
+		case -1:
+			b.WriteString("  Alpha band: none\n")
+		default:
+			b.WriteString(fmt.Sprintf("  Alpha band: %d\n", bandCfg.AlphaBand))
+		}
+		switch bandCfg.Rescale {
+		case cog.RescaleLinear:
+			b.WriteString(fmt.Sprintf("  Rescale: linear [%.0f, %.0f]\n", bandCfg.RescaleMin, bandCfg.RescaleMax))
+		case cog.RescaleLog:
+			b.WriteString(fmt.Sprintf("  Rescale: log [%.0f, %.0f]\n", bandCfg.RescaleMin, bandCfg.RescaleMax))
+		}
 	}
 
 	b.WriteString("\n")
@@ -464,6 +515,102 @@ func parseHexColor(s string) (color.RGBA, error) {
 	}
 
 	return color.RGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: uint8(a)}, nil
+}
+
+// parseBandConfig parses CLI flags into a cog.BandConfig.
+func parseBandConfig(bandsStr, alphaBandStr, rescaleStr, rescaleRange string, firstSrc *cog.Reader) (cog.BandConfig, error) {
+	var cfg cog.BandConfig
+
+	// Parse --bands.
+	parts := strings.Split(bandsStr, ",")
+	if len(parts) != 3 {
+		return cfg, fmt.Errorf("--bands must be 3 comma-separated band numbers (e.g. \"1,2,3\"), got %q", bandsStr)
+	}
+	for i, p := range parts {
+		v, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || v < 1 {
+			return cfg, fmt.Errorf("invalid band number %q (must be >= 1)", p)
+		}
+		cfg.Bands[i] = v
+	}
+
+	// Parse --alpha-band.
+	switch alphaBandStr {
+	case "auto":
+		cfg.AlphaBand = 0
+	default:
+		v, err := strconv.Atoi(strings.TrimSpace(alphaBandStr))
+		if err != nil {
+			return cfg, fmt.Errorf("--alpha-band must be \"auto\" or an integer, got %q", alphaBandStr)
+		}
+		cfg.AlphaBand = v
+	}
+
+	// Parse --rescale and --rescale-range.
+	is16 := firstSrc.BitsPerSample() == 16
+	switch rescaleStr {
+	case "auto":
+		if is16 {
+			cfg.Rescale = cog.RescaleLinear
+			cfg.RescaleMin = 0
+			cfg.RescaleMax = 65535
+			if rescaleRange != "" {
+				minV, maxV, err := parseRange(rescaleRange)
+				if err != nil {
+					return cfg, fmt.Errorf("--rescale-range: %w", err)
+				}
+				cfg.RescaleMin = minV
+				cfg.RescaleMax = maxV
+			}
+		} else {
+			cfg.Rescale = cog.RescaleNone
+		}
+	case "linear":
+		if rescaleRange == "" {
+			return cfg, fmt.Errorf("--rescale-range is required when --rescale is set to %q", rescaleStr)
+		}
+		minV, maxV, err := parseRange(rescaleRange)
+		if err != nil {
+			return cfg, fmt.Errorf("--rescale-range: %w", err)
+		}
+		cfg.Rescale = cog.RescaleLinear
+		cfg.RescaleMin = minV
+		cfg.RescaleMax = maxV
+	case "log":
+		if rescaleRange == "" {
+			return cfg, fmt.Errorf("--rescale-range is required when --rescale is set to %q", rescaleStr)
+		}
+		minV, maxV, err := parseRange(rescaleRange)
+		if err != nil {
+			return cfg, fmt.Errorf("--rescale-range: %w", err)
+		}
+		cfg.Rescale = cog.RescaleLog
+		cfg.RescaleMin = minV
+		cfg.RescaleMax = maxV
+	case "none":
+		cfg.Rescale = cog.RescaleNone
+	default:
+		return cfg, fmt.Errorf("--rescale must be auto, linear, log, or none, got %q", rescaleStr)
+	}
+
+	return cfg, nil
+}
+
+// parseRange parses a "min,max" string into two float64 values.
+func parseRange(s string) (float64, float64, error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected min,max format, got %q", s)
+	}
+	minV, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid min value %q: %w", parts[0], err)
+	}
+	maxV, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid max value %q: %w", parts[1], err)
+	}
+	return minV, maxV, nil
 }
 
 func humanSize(bytes int64) string {

--- a/internal/cog/ifd.go
+++ b/internal/cog/ifd.go
@@ -80,6 +80,14 @@ type IFD struct {
 	NoData          string
 }
 
+// bytesPerSample returns the number of bytes per sample (1 for 8-bit, 2 for 16-bit).
+func (ifd *IFD) bytesPerSample() int {
+	if len(ifd.BitsPerSample) > 0 && ifd.BitsPerSample[0] == 16 {
+		return 2
+	}
+	return 1
+}
+
 // TilesAcross returns the number of tiles in the horizontal direction.
 func (ifd *IFD) TilesAcross() int {
 	return int((ifd.Width + ifd.TileWidth - 1) / ifd.TileWidth)

--- a/internal/cog/ifd.go
+++ b/internal/cog/ifd.go
@@ -2,9 +2,12 @@ package cog
 
 import (
 	"encoding/binary"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"math"
+	"strconv"
+	"strings"
 )
 
 // TIFF tag IDs.
@@ -31,6 +34,7 @@ const (
 	tagGeoKeyDirectoryTag = 34735
 	tagGeoDoubleParamsTag = 34736
 	tagGeoAsciiParamsTag  = 34737
+	tagGDALMetadata       = 42112
 	tagGDAL_NODATA        = 42113
 )
 
@@ -78,6 +82,14 @@ type IFD struct {
 	GeoDoubleParams []float64
 	GeoAsciiParams  string
 	NoData          string
+	GDALMetadata    *GDALMeta // parsed GDAL_METADATA XML (tag 42112), nil if absent
+}
+
+// GDALMeta holds parsed GDAL_METADATA XML items from tag 42112.
+// Dataset-level items go in Items; per-band items (with sample=N) go in BandItems.
+type GDALMeta struct {
+	Items     map[string]string         // dataset-level: name → value
+	BandItems map[int]map[string]string // per-band: sample (0-indexed) → name → value
 }
 
 // bytesPerSample returns the number of bytes per sample (1 for 8-bit, 2 for 16-bit).
@@ -352,10 +364,68 @@ func buildIFD(entries []tiffEntry, bo binary.ByteOrder) IFD {
 			ifd.NoData = s
 		case tagGeoAsciiParamsTag:
 			ifd.GeoAsciiParams = string(e.Value[:e.Count])
+		case tagGDALMetadata:
+			s := string(e.Value[:e.Count])
+			for len(s) > 0 && s[len(s)-1] == 0 {
+				s = s[:len(s)-1]
+			}
+			ifd.GDALMetadata = parseGDALMetadataXML(s)
 		}
 	}
 
 	return ifd
+}
+
+// parseGDALMetadataXML extracts <Item name="key" sample="N">value</Item> pairs
+// from the GDAL_METADATA XML tag (tag 42112). Items with a sample attribute are
+// stored as per-band metadata; items without are dataset-level.
+func parseGDALMetadataXML(xmlStr string) *GDALMeta {
+	meta := &GDALMeta{
+		Items:     make(map[string]string),
+		BandItems: make(map[int]map[string]string),
+	}
+	decoder := xml.NewDecoder(strings.NewReader(xmlStr))
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			break
+		}
+		se, ok := tok.(xml.StartElement)
+		if !ok || se.Name.Local != "Item" {
+			continue
+		}
+		var name string
+		sample := -1
+		for _, attr := range se.Attr {
+			switch attr.Name.Local {
+			case "name":
+				name = attr.Value
+			case "sample":
+				if v, err := strconv.Atoi(attr.Value); err == nil {
+					sample = v
+				}
+			}
+		}
+		if name == "" {
+			continue
+		}
+		var value string
+		if err := decoder.DecodeElement(&value, &se); err != nil {
+			continue
+		}
+		if sample >= 0 {
+			if meta.BandItems[sample] == nil {
+				meta.BandItems[sample] = make(map[string]string)
+			}
+			meta.BandItems[sample][name] = value
+		} else {
+			meta.Items[name] = value
+		}
+	}
+	if len(meta.Items) == 0 && len(meta.BandItems) == 0 {
+		return nil
+	}
+	return meta
 }
 
 func getUint16Val(e tiffEntry, bo binary.ByteOrder) uint16 {

--- a/internal/cog/reader.go
+++ b/internal/cog/reader.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -1347,6 +1348,183 @@ func (r *Reader) BitsPerSample() int {
 // SamplesPerPixel returns the samples per pixel of the first IFD.
 func (r *Reader) SamplesPerPixel() int {
 	return int(r.ifds[0].SamplesPerPixel)
+}
+
+// GDALMeta returns the parsed GDAL_METADATA from tag 42112.
+// Returns nil if the tag was not present.
+func (r *Reader) GDALMeta() *GDALMeta {
+	return r.ifds[0].GDALMetadata
+}
+
+// Preset describes auto-detected settings derived from the GeoTIFF.
+type Preset struct {
+	Name    string     // e.g. "multispectral-rgbnir", "float-terrarium"
+	BandCfg BandConfig // fully configured bands, rescale, alpha (zero value for float)
+	Format  string     // suggested output format ("terrarium", ""), empty = no override
+}
+
+// bandRoleKeywords maps canonical color roles to GDAL band DESCRIPTION keywords.
+// Matching is case-insensitive. The first keyword match wins for each role.
+var bandRoleKeywords = map[string][]string{
+	"red":   {"red"},
+	"green": {"green"},
+	"blue":  {"blue"},
+	"nir":   {"nir", "near-infrared", "near infrared", "infrared"},
+}
+
+// bandItemRe matches "Band N: BXX (Role)" in a dataset-level "bands" string.
+var bandItemRe = regexp.MustCompile(`Band\s+(\d+):\s+\S+\s+\((\w+)\)`)
+
+// DetectPreset examines the GeoTIFF structure and GDAL metadata to return a Preset.
+// Detection covers:
+//   - Float data (elevation/DEM) → terrarium format
+//   - Multi-band with band descriptions → auto band mapping + rescaling
+func (r *Reader) DetectPreset() (Preset, bool) {
+	// Float data → terrarium encoding.
+	if r.IsFloat() {
+		return Preset{Name: "float-terrarium", Format: "terrarium"}, true
+	}
+
+	// Multi-band with GDAL metadata → auto band mapping + rescaling.
+	md := r.GDALMeta()
+	if md == nil {
+		return Preset{}, false
+	}
+
+	roleToFileBand := r.detectBandRoles(md)
+
+	redBand, okR := roleToFileBand["red"]
+	greenBand, okG := roleToFileBand["green"]
+	blueBand, okB := roleToFileBand["blue"]
+	if !okR || !okG || !okB {
+		return Preset{}, false
+	}
+
+	rescaleMin, rescaleMax := r.detectScale(md)
+
+	name := "multispectral"
+	if _, hasNIR := roleToFileBand["nir"]; hasNIR {
+		name += "-rgbnir"
+	} else {
+		name += "-rgb"
+	}
+
+	cfg := BandConfig{
+		Bands:      [3]int{redBand, greenBand, blueBand},
+		AlphaBand:  -1,
+		Rescale:    RescaleLinear,
+		RescaleMin: rescaleMin,
+		RescaleMax: rescaleMax,
+	}
+
+	return Preset{Name: name, BandCfg: cfg}, true
+}
+
+// detectBandRoles maps color roles (red, green, blue, nir) to 1-indexed file bands
+// by examining GDAL metadata. Checks per-band DESCRIPTION items first, then falls
+// back to parsing a dataset-level "bands" string.
+func (r *Reader) detectBandRoles(md *GDALMeta) map[string]int {
+	roleToFileBand := make(map[string]int)
+
+	// Strategy 1: per-band DESCRIPTION items.
+	for sample, items := range md.BandItems {
+		desc := strings.ToLower(strings.TrimSpace(items["DESCRIPTION"]))
+		if desc == "" {
+			continue
+		}
+		for role, keywords := range bandRoleKeywords {
+			if _, exists := roleToFileBand[role]; exists {
+				continue
+			}
+			for _, kw := range keywords {
+				if strings.Contains(desc, kw) {
+					roleToFileBand[role] = sample + 1
+					break
+				}
+			}
+		}
+	}
+
+	// If we found at least RGB, we're done.
+	if _, okR := roleToFileBand["red"]; okR {
+		if _, okG := roleToFileBand["green"]; okG {
+			if _, okB := roleToFileBand["blue"]; okB {
+				return roleToFileBand
+			}
+		}
+	}
+
+	// Strategy 2: dataset-level "bands" string, e.g.
+	// "Band 1: B04 (Red), Band 2: B03 (Green), Band 3: B02 (Blue), Band 4: B08 (Infrared)"
+	if bandsStr := md.Items["bands"]; bandsStr != "" {
+		matches := bandItemRe.FindAllStringSubmatch(bandsStr, -1)
+		for _, m := range matches {
+			bandIdx, _ := strconv.Atoi(m[1])
+			role := strings.ToLower(m[2])
+			// Map the role through our keyword table.
+			for canonRole, keywords := range bandRoleKeywords {
+				if _, exists := roleToFileBand[canonRole]; exists {
+					continue
+				}
+				for _, kw := range keywords {
+					if strings.Contains(role, kw) {
+						roleToFileBand[canonRole] = bandIdx
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return roleToFileBand
+}
+
+// detectScale reads SCALE and OFFSET from GDAL metadata and returns the rescale
+// range [min, max] for mapping to [0, 255]. Checks per-band items first (sample 0),
+// then dataset-level items.
+func (r *Reader) detectScale(md *GDALMeta) (float64, float64) {
+	var scaleStr, offsetStr string
+
+	// Per-band SCALE/OFFSET (sample 0) take precedence.
+	if items, ok := md.BandItems[0]; ok {
+		scaleStr = items["SCALE"]
+		offsetStr = items["OFFSET"]
+	}
+	// Fall back to dataset-level.
+	if scaleStr == "" {
+		scaleStr = md.Items["SCALE"]
+	}
+	if offsetStr == "" {
+		offsetStr = md.Items["OFFSET"]
+	}
+
+	if scaleStr == "" {
+		return 0, 10000 // sensible default for reflectance data
+	}
+
+	scale, err := strconv.ParseFloat(strings.TrimSpace(scaleStr), 64)
+	if err != nil || scale <= 0 {
+		return 0, 10000
+	}
+
+	maxVal := math.Round(1.0 / scale) // e.g. 0.0001 → 10000
+
+	var offset float64
+	if offsetStr != "" {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(offsetStr), 64); err == nil {
+			offset = v
+		}
+	}
+
+	// Offset adjusts the min value: reflectance = (DN + offset) * scale
+	// So DN range for [0, 1] reflectance is [-offset/scale, (1-offset*scale)/scale]
+	// Simplified: min = -offset/scale (if offset < 0, e.g. Landsat: offset=-0.2, scale=0.0000275)
+	minVal := 0.0
+	if offset < 0 {
+		minVal = math.Round(-offset / scale)
+	}
+
+	return minVal, maxVal
 }
 
 // buildRescaler returns a function that maps uint16 input values to uint8 output.

--- a/internal/cog/reader.go
+++ b/internal/cog/reader.go
@@ -16,6 +16,25 @@ import (
 	"strings"
 )
 
+// RescaleMode specifies how to rescale sample values to uint8.
+type RescaleMode int
+
+const (
+	RescaleNone   RescaleMode = iota // No rescaling (identity for 8-bit)
+	RescaleLinear                    // Linear mapping from [min,max] → [0,255]
+	RescaleLog                       // Logarithmic mapping from [min,max] → [0,255]
+)
+
+// BandConfig controls band selection, alpha handling, and rescaling for multi-band GeoTIFFs.
+// Zero value produces identical behavior to the legacy code path (bands 1,2,3; auto alpha for spp≥4; no rescaling).
+type BandConfig struct {
+	Bands      [3]int      // 1-indexed input band → R,G,B output. Zero value = default (1,2,3)
+	AlphaBand  int         // 1-indexed alpha band. 0=auto, -1=none
+	Rescale    RescaleMode // Rescaling mode
+	RescaleMin float64     // Input value range minimum
+	RescaleMax float64     // Input value range maximum
+}
+
 // Bounds represents geographic bounds in WGS84.
 type Bounds struct {
 	MinLon, MaxLon float64
@@ -30,13 +49,14 @@ func (b Bounds) CenterLat() float64 {
 // Reader provides tile-level access to a COG/GeoTIFF file.
 // The file is memory-mapped for lock-free concurrent access.
 type Reader struct {
-	data  []byte // memory-mapped file contents
-	bo    binary.ByteOrder
-	ifds  []IFD
-	geo   GeoInfo
-	path  string
-	id    int          // unique numeric ID for fast cache keying (set by OpenAll)
-	strip *stripLayout // non-nil for strip-based TIFFs promoted to virtual tiles
+	data    []byte // memory-mapped file contents
+	bo      binary.ByteOrder
+	ifds    []IFD
+	geo     GeoInfo
+	path    string
+	id      int          // unique numeric ID for fast cache keying (set by OpenAll)
+	strip   *stripLayout // non-nil for strip-based TIFFs promoted to virtual tiles
+	bandCfg BandConfig   // band selection and rescaling config (set via SetBandConfig)
 }
 
 // stripLayout stores the original strip layout for strip-based TIFFs.
@@ -314,7 +334,7 @@ func (r *Reader) readTileRaw(level, col, row int) ([]byte, *IFD, error) {
 	}
 
 	if ifd.Predictor == 2 {
-		undoHorizontalDifferencing(decompressed, int(ifd.TileWidth), int(ifd.SamplesPerPixel))
+		undoHorizontalDifferencing(decompressed, int(ifd.TileWidth), int(ifd.SamplesPerPixel), ifd.bytesPerSample(), r.bo)
 	}
 	return decompressed, ifd, nil
 }
@@ -371,7 +391,7 @@ func (r *Reader) readStripTileRaw(ifd *IFD, tileRow int) ([]byte, *IFD, error) {
 	}
 
 	if ifd.Predictor == 2 {
-		undoHorizontalDifferencing(combined, int(ifd.Width), int(ifd.SamplesPerPixel))
+		undoHorizontalDifferencing(combined, int(ifd.Width), int(ifd.SamplesPerPixel), ifd.bytesPerSample(), r.bo)
 	}
 	return combined, ifd, nil
 }
@@ -379,8 +399,24 @@ func (r *Reader) readStripTileRaw(ifd *IFD, tileRow int) ([]byte, *IFD, error) {
 // undoHorizontalDifferencing reverses TIFF predictor=2 (horizontal differencing).
 // Each sample is stored as the difference from the previous sample in the same row.
 // This accumulates the deltas to recover the original values.
-func undoHorizontalDifferencing(data []byte, width, samplesPerPixel int) {
-	rowBytes := width * samplesPerPixel
+// For 16-bit data (bytesPerSample=2), deltas are uint16 values read/written via bo.
+func undoHorizontalDifferencing(data []byte, width, samplesPerPixel, bytesPerSample int, bo binary.ByteOrder) {
+	rowBytes := width * samplesPerPixel * bytesPerSample
+	if bytesPerSample == 2 {
+		for off := 0; off+rowBytes <= len(data); off += rowBytes {
+			row := data[off : off+rowBytes]
+			// Start at the second pixel (first pixel is stored as-is).
+			for x := samplesPerPixel; x < width*samplesPerPixel; x++ {
+				byteOff := x * 2
+				prevOff := (x - samplesPerPixel) * 2
+				cur := bo.Uint16(row[byteOff : byteOff+2])
+				prev := bo.Uint16(row[prevOff : prevOff+2])
+				bo.PutUint16(row[byteOff:byteOff+2], cur+prev)
+			}
+		}
+		return
+	}
+	// 8-bit path (unchanged).
 	for off := 0; off+rowBytes <= len(data); off += rowBytes {
 		row := data[off : off+rowBytes]
 		for x := samplesPerPixel; x < rowBytes; x++ {
@@ -500,7 +536,7 @@ func (r *Reader) ReadTile(level, col, row int) (image.Image, error) {
 		if ifd.Predictor == 2 {
 			buf := make([]byte, len(data))
 			copy(buf, data)
-			undoHorizontalDifferencing(buf, int(ifd.TileWidth), int(ifd.SamplesPerPixel))
+			undoHorizontalDifferencing(buf, int(ifd.TileWidth), int(ifd.SamplesPerPixel), ifd.bytesPerSample(), r.bo)
 			return r.decodeRawTile(ifd, buf)
 		}
 		return r.decodeRawTile(ifd, data)
@@ -510,7 +546,7 @@ func (r *Reader) ReadTile(level, col, row int) (image.Image, error) {
 			return nil, fmt.Errorf("decompressing deflate tile: %w", err)
 		}
 		if ifd.Predictor == 2 {
-			undoHorizontalDifferencing(decompressed, int(ifd.TileWidth), int(ifd.SamplesPerPixel))
+			undoHorizontalDifferencing(decompressed, int(ifd.TileWidth), int(ifd.SamplesPerPixel), ifd.bytesPerSample(), r.bo)
 		}
 		return r.decodeRawTile(ifd, decompressed)
 	case 5: // LZW
@@ -519,7 +555,7 @@ func (r *Reader) ReadTile(level, col, row int) (image.Image, error) {
 			return nil, fmt.Errorf("decompressing LZW tile: %w", err)
 		}
 		if ifd.Predictor == 2 {
-			undoHorizontalDifferencing(decompressed, int(ifd.TileWidth), int(ifd.SamplesPerPixel))
+			undoHorizontalDifferencing(decompressed, int(ifd.TileWidth), int(ifd.SamplesPerPixel), ifd.bytesPerSample(), r.bo)
 		}
 		return r.decodeRawTile(ifd, decompressed)
 	default:
@@ -585,16 +621,56 @@ func (r *Reader) decodeJPEGTile(ifd *IFD, data []byte) (image.Image, error) {
 }
 
 // decodeRawTile decodes an uncompressed tile.
-// For single-band data, pixels matching the GDAL nodata value are set to
-// alpha=0 (transparent) so downstream code treats them as empty.
+// Supports 8-bit and 16-bit samples, band reordering, alpha band selection, and rescaling
+// via the reader's BandConfig. For single-band data, pixels matching the GDAL nodata value
+// are set to alpha=0 (transparent) so downstream code treats them as empty.
+// Zero-value BandConfig produces identical behavior to the legacy code path.
 func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 	w := int(ifd.TileWidth)
 	h := int(ifd.TileHeight)
 	spp := int(ifd.SamplesPerPixel)
+	bps := ifd.bytesPerSample() // 1 for 8-bit, 2 for 16-bit
+	is16 := bps == 2
+	pixelBytes := spp * bps
 
+	// Resolve band mapping from config (with defaults).
+	cfg := r.bandCfg
+	bandR, bandG, bandB := cfg.Bands[0], cfg.Bands[1], cfg.Bands[2]
+	if bandR == 0 {
+		bandR = 1
+	}
+	if bandG == 0 {
+		bandG = 2
+	}
+	if bandB == 0 {
+		bandB = 3
+	}
+	// Convert to 0-indexed.
+	bandR--
+	bandG--
+	bandB--
+
+	// Resolve alpha band: 0=auto, -1=none, >0=explicit (1-indexed).
+	alphaBand := cfg.AlphaBand
+	effectiveAlpha := -1 // -1 means no alpha band
+	if alphaBand == 0 {
+		// Auto: band 4 (0-indexed: 3) for 8-bit spp≥4 with zero-value BandConfig.
+		if !is16 && spp >= 4 {
+			effectiveAlpha = 3
+		}
+	} else if alphaBand > 0 {
+		effectiveAlpha = alphaBand - 1 // convert to 0-indexed
+	}
+	// alphaBand == -1 → effectiveAlpha stays -1 (no alpha)
+
+	// Determine if we're in the legacy single-band nodata path.
+	// Only for spp≤2, no explicit band config, and no alpha band.
+	useLegacyNodata := false
 	var hasNodata bool
 	var nodataVal uint8
-	if spp <= 2 {
+	isDefaultBandCfg := cfg.Bands == [3]int{} && cfg.AlphaBand == 0 && cfg.Rescale == RescaleNone
+	if spp <= 2 && isDefaultBandCfg && !is16 {
+		useLegacyNodata = true
 		nd := r.ifds[0].NoData
 		if nd != "" {
 			v, err := strconv.ParseFloat(strings.TrimSpace(nd), 64)
@@ -605,50 +681,93 @@ func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 		}
 	}
 
+	// Build rescaler.
+	rescale := buildRescaler(cfg.Rescale, cfg.RescaleMin, cfg.RescaleMax)
+
+	// readSample reads one sample from the pixel data at the given 0-indexed band.
+	readSample := func(pixelOff, band int) uint16 {
+		off := pixelOff + band*bps
+		if off+bps > len(data) {
+			return 0
+		}
+		if is16 {
+			return r.bo.Uint16(data[off : off+2])
+		}
+		return uint16(data[off])
+	}
+
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	pix := img.Pix
+
 	for y := 0; y < h; y++ {
 		for x := 0; x < w; x++ {
-			idx := (y*w + x) * spp
-			if idx+spp > len(data) {
+			pixelOff := (y*w + x) * pixelBytes
+			if pixelOff+pixelBytes > len(data) {
 				break
 			}
-			var c color.RGBA
-			switch spp {
-			case 1:
-				v := data[idx]
-				c.R = v
-				c.G = v
-				c.B = v
-				if hasNodata && v == nodataVal {
-					c.A = 0
-				} else {
-					c.A = 255
+			pixIdx := (y*w + x) * 4
+
+			if useLegacyNodata {
+				// Legacy path for 8-bit spp≤2 with default config.
+				switch spp {
+				case 1:
+					v := data[pixelOff]
+					pix[pixIdx+0] = v
+					pix[pixIdx+1] = v
+					pix[pixIdx+2] = v
+					if hasNodata && v == nodataVal {
+						pix[pixIdx+3] = 0
+					} else {
+						pix[pixIdx+3] = 255
+					}
+				case 2:
+					v := data[pixelOff]
+					pix[pixIdx+0] = v
+					pix[pixIdx+1] = v
+					pix[pixIdx+2] = v
+					a := data[pixelOff+1]
+					if hasNodata && v == nodataVal {
+						a = 0
+					}
+					pix[pixIdx+3] = a
 				}
-			case 2:
-				v := data[idx]
-				c.R = v
-				c.G = v
-				c.B = v
-				a := data[idx+1]
-				if hasNodata && v == nodataVal {
-					a = 0
+				continue
+			}
+
+			// General path: band reordering + rescaling.
+			var rV, gV, bV uint16
+			if bandR < spp {
+				rV = readSample(pixelOff, bandR)
+			}
+			if spp > 1 && bandG < spp {
+				gV = readSample(pixelOff, bandG)
+			}
+			if spp > 2 && bandB < spp {
+				bV = readSample(pixelOff, bandB)
+			}
+
+			// Alpha.
+			var a uint8 = 255
+			if effectiveAlpha >= 0 && effectiveAlpha < spp {
+				rawAlpha := readSample(pixelOff, effectiveAlpha)
+				if rawAlpha == 0 {
+					// Transparent source pixel: leave as alpha=0.
+					pix[pixIdx+0] = 0
+					pix[pixIdx+1] = 0
+					pix[pixIdx+2] = 0
+					pix[pixIdx+3] = 0
+					continue
 				}
-				c.A = a
-			default:
-				c.R = data[idx]
-				if spp > 1 {
-					c.G = data[idx+1]
-				}
-				if spp > 2 {
-					c.B = data[idx+2]
-				}
-				if spp > 3 {
-					c.A = data[idx+3]
-				} else {
-					c.A = 255
+				a = rescale(rawAlpha)
+				if a == 0 {
+					a = 1 // Avoid fully transparent for non-zero source alpha
 				}
 			}
-			img.SetRGBA(x, y, c)
+
+			pix[pixIdx+0] = rescale(rV)
+			pix[pixIdx+1] = rescale(gV)
+			pix[pixIdx+2] = rescale(bV)
+			pix[pixIdx+3] = a
 		}
 	}
 	return img, nil
@@ -1199,4 +1318,62 @@ func (r *Reader) IsFloat() bool {
 // NoData returns the GDAL nodata string, or "" if not set.
 func (r *Reader) NoData() string {
 	return r.ifds[0].NoData
+}
+
+// SetBandConfig sets the band selection and rescaling configuration.
+// Must be called after OpenAll() and before any ReadTile() calls.
+func (r *Reader) SetBandConfig(cfg BandConfig) {
+	r.bandCfg = cfg
+}
+
+// BitsPerSample returns the bits per sample of the first IFD (e.g. 8, 16).
+func (r *Reader) BitsPerSample() int {
+	if len(r.ifds[0].BitsPerSample) > 0 {
+		return int(r.ifds[0].BitsPerSample[0])
+	}
+	return 8
+}
+
+// SamplesPerPixel returns the samples per pixel of the first IFD.
+func (r *Reader) SamplesPerPixel() int {
+	return int(r.ifds[0].SamplesPerPixel)
+}
+
+// buildRescaler returns a function that maps uint16 input values to uint8 output.
+func buildRescaler(mode RescaleMode, minVal, maxVal float64) func(uint16) uint8 {
+	switch mode {
+	case RescaleLinear:
+		if maxVal == minVal {
+			return func(uint16) uint8 { return 0 }
+		}
+		scale := 255.0 / (maxVal - minVal)
+		return func(v uint16) uint8 {
+			f := float64(v)
+			if f < minVal {
+				return 0
+			}
+			if f > maxVal {
+				return 255
+			}
+			return uint8(math.Round((f - minVal) * scale))
+		}
+	case RescaleLog:
+		if maxVal == minVal {
+			return func(uint16) uint8 { return 0 }
+		}
+		logRange := math.Log(1 + maxVal - minVal)
+		scale := 255.0 / logRange
+		return func(v uint16) uint8 {
+			f := float64(v)
+			if f < minVal {
+				return 0
+			}
+			if f > maxVal {
+				return 255
+			}
+			return uint8(math.Round(math.Log(1+f-minVal) * scale))
+		}
+	default: // RescaleNone
+		return func(v uint16) uint8 { return uint8(v) }
+	}
 }

--- a/internal/cog/reader.go
+++ b/internal/cog/reader.go
@@ -681,8 +681,18 @@ func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 		}
 	}
 
-	// Build rescaler.
-	rescale := buildRescaler(cfg.Rescale, cfg.RescaleMin, cfg.RescaleMax)
+	// Build rescaler. For 16-bit data with no explicit rescaling (e.g. coginfo
+	// or debug tools using zero-value BandConfig), fall back to linear 0-65535
+	// so values are at least visible rather than uint8-truncated.
+	rescaleMode := cfg.Rescale
+	rescaleMin := cfg.RescaleMin
+	rescaleMax := cfg.RescaleMax
+	if is16 && rescaleMode == RescaleNone {
+		rescaleMode = RescaleLinear
+		rescaleMin = 0
+		rescaleMax = 65535
+	}
+	rescale := buildRescaler(rescaleMode, rescaleMin, rescaleMax)
 
 	// readSample reads one sample from the pixel data at the given 0-indexed band.
 	readSample := func(pixelOff, band int) uint16 {

--- a/internal/cog/reader_test.go
+++ b/internal/cog/reader_test.go
@@ -411,6 +411,361 @@ func TestIFDBytesPerSample(t *testing.T) {
 	}
 }
 
+func TestParseGDALMetadata(t *testing.T) {
+	xmlStr := `<GDALMetadata>
+  <Item name="product_type">Sentinel-2 median L2A (RGBNIR) composite</Item>
+  <Item name="bands">Band 1: B04 (Red), Band 2: B03 (Green), Band 3: B02 (Blue), Band 4: B08 (Infrared)</Item>
+  <Item name="SCALE" sample="0" role="scale">0.000100000000000000005</Item>
+  <Item name="description">ESA WorldCover S2 RGBNIR 10m v200</Item>
+</GDALMetadata>`
+
+	result := parseGDALMetadataXML(xmlStr)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Dataset-level items (no sample attribute).
+	wantItems := map[string]string{
+		"product_type": "Sentinel-2 median L2A (RGBNIR) composite",
+		"bands":        "Band 1: B04 (Red), Band 2: B03 (Green), Band 3: B02 (Blue), Band 4: B08 (Infrared)",
+		"description":  "ESA WorldCover S2 RGBNIR 10m v200",
+	}
+	for key, want := range wantItems {
+		got, ok := result.Items[key]
+		if !ok {
+			t.Errorf("missing dataset-level key %q", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("key %q: got %q, want %q", key, got, want)
+		}
+	}
+
+	// Per-band items (sample="0").
+	band0, ok := result.BandItems[0]
+	if !ok {
+		t.Fatal("missing band 0 items")
+	}
+	if got := band0["SCALE"]; got != "0.000100000000000000005" {
+		t.Errorf("band 0 SCALE = %q, want %q", got, "0.000100000000000000005")
+	}
+}
+
+func TestParseGDALMetadataPerBand(t *testing.T) {
+	// GDAL-standard per-band DESCRIPTION items (e.g. from GEE exports or gdal_translate).
+	xmlStr := `<GDALMetadata>
+  <Item name="DESCRIPTION" sample="0" role="description">Red</Item>
+  <Item name="DESCRIPTION" sample="1" role="description">Green</Item>
+  <Item name="DESCRIPTION" sample="2" role="description">Blue</Item>
+  <Item name="DESCRIPTION" sample="3" role="description">NIR</Item>
+  <Item name="SCALE" sample="0" role="scale">0.0001</Item>
+  <Item name="OFFSET" sample="0" role="offset">0</Item>
+</GDALMetadata>`
+
+	result := parseGDALMetadataXML(xmlStr)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Should have no dataset-level items.
+	if len(result.Items) != 0 {
+		t.Errorf("expected 0 dataset-level items, got %d", len(result.Items))
+	}
+
+	// Should have 4 bands.
+	if len(result.BandItems) != 4 {
+		t.Errorf("expected 4 bands, got %d", len(result.BandItems))
+	}
+
+	wantDescs := []string{"Red", "Green", "Blue", "NIR"}
+	for i, want := range wantDescs {
+		got := result.BandItems[i]["DESCRIPTION"]
+		if got != want {
+			t.Errorf("band %d DESCRIPTION = %q, want %q", i, got, want)
+		}
+	}
+
+	if got := result.BandItems[0]["SCALE"]; got != "0.0001" {
+		t.Errorf("band 0 SCALE = %q, want %q", got, "0.0001")
+	}
+}
+
+func TestParseGDALMetadataEmpty(t *testing.T) {
+	result := parseGDALMetadataXML("")
+	if result != nil {
+		t.Errorf("expected nil for empty string")
+	}
+
+	result2 := parseGDALMetadataXML("<GDALMetadata></GDALMetadata>")
+	if result2 != nil {
+		t.Errorf("expected nil for empty root")
+	}
+}
+
+func TestDetectPresetFromBandsString(t *testing.T) {
+	// Dataset-level "bands" item (e.g. ESA WorldCover S2 RGBNIR).
+	// No per-band DESCRIPTION — roles extracted from "Band N: BXX (Role)" format.
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{16, 16, 16, 16},
+			SamplesPerPixel: 4,
+			GDALMetadata: &GDALMeta{
+				Items: map[string]string{
+					"bands": "Band 1: B04 (Red), Band 2: B03 (Green), Band 3: B02 (Blue), Band 4: B08 (Infrared)",
+				},
+				BandItems: map[int]map[string]string{
+					0: {"SCALE": "0.000100000000000000005"},
+				},
+			},
+		}},
+	}
+
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset to be detected from bands string")
+	}
+	if preset.Name != "multispectral-rgbnir" {
+		t.Errorf("name = %q, want %q", preset.Name, "multispectral-rgbnir")
+	}
+	// Red=1, Green=2, Blue=3 (matching band numbers in the string).
+	if preset.BandCfg.Bands != [3]int{1, 2, 3} {
+		t.Errorf("bands = %v, want [1,2,3]", preset.BandCfg.Bands)
+	}
+	if preset.BandCfg.AlphaBand != -1 {
+		t.Errorf("alpha band = %d, want -1", preset.BandCfg.AlphaBand)
+	}
+	if preset.BandCfg.Rescale != RescaleLinear {
+		t.Errorf("rescale = %d, want RescaleLinear", preset.BandCfg.Rescale)
+	}
+	if preset.BandCfg.RescaleMax != 10000 {
+		t.Errorf("rescale max = %.0f, want 10000", preset.BandCfg.RescaleMax)
+	}
+}
+
+func TestDetectPresetFromBandsStringReordered(t *testing.T) {
+	// Reordered bands: Blue first.
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{16, 16, 16, 16},
+			SamplesPerPixel: 4,
+			GDALMetadata: &GDALMeta{
+				Items: map[string]string{
+					"bands": "Band 1: B02 (Blue), Band 2: B03 (Green), Band 3: B04 (Red), Band 4: B08 (Infrared)",
+				},
+				BandItems: map[int]map[string]string{
+					0: {"SCALE": "0.0001"},
+				},
+			},
+		}},
+	}
+
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset to be detected")
+	}
+	// Red=band3, Green=band2, Blue=band1.
+	if preset.BandCfg.Bands != [3]int{3, 2, 1} {
+		t.Errorf("bands = %v, want [3,2,1]", preset.BandCfg.Bands)
+	}
+}
+
+func TestDetectPresetGDALStandardDescriptions(t *testing.T) {
+	// GDAL-standard per-band DESCRIPTION items (e.g. GEE export, PlanetScope).
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{16, 16, 16, 16},
+			SamplesPerPixel: 4,
+			GDALMetadata: &GDALMeta{
+				Items: map[string]string{},
+				BandItems: map[int]map[string]string{
+					0: {"DESCRIPTION": "Blue", "SCALE": "0.0001"},
+					1: {"DESCRIPTION": "Green"},
+					2: {"DESCRIPTION": "Red"},
+					3: {"DESCRIPTION": "NIR"},
+				},
+			},
+		}},
+	}
+
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset to be detected from GDAL band descriptions")
+	}
+	if preset.Name != "multispectral-rgbnir" {
+		t.Errorf("name = %q, want %q", preset.Name, "multispectral-rgbnir")
+	}
+	// Blue=band1(sample0), Green=band2(sample1), Red=band3(sample2), NIR=band4(sample3)
+	// So: R=3, G=2, B=1
+	if preset.BandCfg.Bands != [3]int{3, 2, 1} {
+		t.Errorf("bands = %v, want [3,2,1]", preset.BandCfg.Bands)
+	}
+	if preset.BandCfg.RescaleMax != 10000 {
+		t.Errorf("rescale max = %.0f, want 10000", preset.BandCfg.RescaleMax)
+	}
+}
+
+func TestDetectPresetGDALStandardRGBOnly(t *testing.T) {
+	// 3-band RGB with GDAL descriptions, no NIR.
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{16, 16, 16},
+			SamplesPerPixel: 3,
+			GDALMetadata: &GDALMeta{
+				Items: map[string]string{},
+				BandItems: map[int]map[string]string{
+					0: {"DESCRIPTION": "Red", "SCALE": "0.0001"},
+					1: {"DESCRIPTION": "Green"},
+					2: {"DESCRIPTION": "Blue"},
+				},
+			},
+		}},
+	}
+
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset")
+	}
+	if preset.Name != "multispectral-rgb" {
+		t.Errorf("name = %q, want %q", preset.Name, "multispectral-rgb")
+	}
+	if preset.BandCfg.Bands != [3]int{1, 2, 3} {
+		t.Errorf("bands = %v, want [1,2,3]", preset.BandCfg.Bands)
+	}
+}
+
+func TestDetectPresetWithOffset(t *testing.T) {
+	// Landsat-style: scale=0.0000275, offset=-0.2 (per-band metadata).
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{16, 16, 16},
+			SamplesPerPixel: 3,
+			GDALMetadata: &GDALMeta{
+				Items: map[string]string{},
+				BandItems: map[int]map[string]string{
+					0: {"DESCRIPTION": "Red", "SCALE": "0.0000275", "OFFSET": "-0.2"},
+					1: {"DESCRIPTION": "Green"},
+					2: {"DESCRIPTION": "Blue"},
+				},
+			},
+		}},
+	}
+
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset")
+	}
+	// 1/0.0000275 ≈ 36364, -(-0.2)/0.0000275 ≈ 7273.
+	if preset.BandCfg.RescaleMin != 7273 {
+		t.Errorf("rescale min = %.0f, want 7273", preset.BandCfg.RescaleMin)
+	}
+	if preset.BandCfg.RescaleMax != 36364 {
+		t.Errorf("rescale max = %.0f, want 36364", preset.BandCfg.RescaleMax)
+	}
+}
+
+func TestDetectPresetFloatTerrarium(t *testing.T) {
+	// Float32 data → terrarium preset.
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{32},
+			SamplesPerPixel: 1,
+			SampleFormat:    []uint16{3}, // IEEE floating point
+		}},
+	}
+
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset for float data")
+	}
+	if preset.Name != "float-terrarium" {
+		t.Errorf("name = %q, want %q", preset.Name, "float-terrarium")
+	}
+	if preset.Format != "terrarium" {
+		t.Errorf("format = %q, want %q", preset.Format, "terrarium")
+	}
+}
+
+func TestDetectPresetNone(t *testing.T) {
+	// 8-bit RGB, no GDAL metadata → no preset.
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{8, 8, 8},
+			SamplesPerPixel: 3,
+		}},
+	}
+	_, ok := r.DetectPreset()
+	if ok {
+		t.Error("expected no preset for 8-bit RGB without GDAL metadata")
+	}
+}
+
+func TestDetectPresetInsufficientBands(t *testing.T) {
+	// GDAL metadata present but only 2 bands described (no Blue).
+	r := &Reader{
+		bo: binary.LittleEndian,
+		ifds: []IFD{{
+			BitsPerSample:   []uint16{16, 16},
+			SamplesPerPixel: 2,
+			GDALMetadata: &GDALMeta{
+				Items: map[string]string{},
+				BandItems: map[int]map[string]string{
+					0: {"DESCRIPTION": "Red"},
+					1: {"DESCRIPTION": "Green"},
+				},
+			},
+		}},
+	}
+	_, ok := r.DetectPreset()
+	if ok {
+		t.Error("expected no preset when Blue band is missing")
+	}
+}
+
+func TestDetectPresetRealFile(t *testing.T) {
+	// Validate against the actual ESA WorldCover S2 RGBNIR file if present.
+	path := "../../data2/ESA_WorldCover_10m_2021_v200_N00E009_S2RGBNIR.tif"
+	r, err := Open(path)
+	if err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+	defer r.Close()
+
+	// Verify GDAL metadata was parsed.
+	md := r.GDALMeta()
+	if md == nil {
+		t.Fatal("expected GDAL metadata")
+	}
+	if got := md.Items["bands"]; got == "" {
+		t.Error("expected non-empty 'bands' item")
+	}
+
+	// Verify auto-detection works.
+	preset, ok := r.DetectPreset()
+	if !ok {
+		t.Fatal("expected preset to be detected")
+	}
+	if preset.Name != "multispectral-rgbnir" {
+		t.Errorf("name = %q, want %q", preset.Name, "multispectral-rgbnir")
+	}
+	// ESA WorldCover: Band 1=Red, Band 2=Green, Band 3=Blue, Band 4=NIR.
+	if preset.BandCfg.Bands != [3]int{1, 2, 3} {
+		t.Errorf("bands = %v, want [1,2,3]", preset.BandCfg.Bands)
+	}
+	if preset.BandCfg.RescaleMax != 10000 {
+		t.Errorf("rescale max = %.0f, want 10000", preset.BandCfg.RescaleMax)
+	}
+	if preset.BandCfg.RescaleMin != 0 {
+		t.Errorf("rescale min = %.0f, want 0", preset.BandCfg.RescaleMin)
+	}
+}
+
 func assertPixel(t *testing.T, img *image.RGBA, x, y int, want color.RGBA) {
 	t.Helper()
 	got := img.RGBAAt(x, y)
@@ -418,4 +773,3 @@ func assertPixel(t *testing.T, img *image.RGBA, x, y int, want color.RGBA) {
 		t.Errorf("pixel(%d,%d) = %v, want %v", x, y, got, want)
 	}
 }
-

--- a/internal/cog/reader_test.go
+++ b/internal/cog/reader_test.go
@@ -1,0 +1,421 @@
+package cog
+
+import (
+	"encoding/binary"
+	"image"
+	"image/color"
+	"testing"
+)
+
+func TestUndoHorizontalDifferencing8Bit(t *testing.T) {
+	// 2 pixels wide, 2 samples per pixel. First pixel stored as-is, second as delta.
+	data := []byte{
+		10, 20, 5, 3, // row 0: pixel0=(10,20), delta1=(5,3) → pixel1=(15,23)
+		100, 200, 10, 6, // row 1: pixel0=(100,200), delta1=(10,6) → pixel1=(110,206)
+	}
+	undoHorizontalDifferencing(data, 2, 2, 1, binary.LittleEndian)
+
+	want := []byte{10, 20, 15, 23, 100, 200, 110, 206}
+	for i := range want {
+		if data[i] != want[i] {
+			t.Errorf("byte %d: got %d, want %d", i, data[i], want[i])
+		}
+	}
+}
+
+func TestUndoHorizontalDifferencing16Bit(t *testing.T) {
+	bo := binary.LittleEndian
+	// 3 pixels wide, 1 sample per pixel (16-bit).
+	// pixel0=1000, delta1=500, delta2=200
+	// Expected: 1000, 1500, 1700
+	data := make([]byte, 6)
+	bo.PutUint16(data[0:2], 1000)
+	bo.PutUint16(data[2:4], 500)
+	bo.PutUint16(data[4:6], 200)
+
+	undoHorizontalDifferencing(data, 3, 1, 2, bo)
+
+	got := []uint16{
+		bo.Uint16(data[0:2]),
+		bo.Uint16(data[2:4]),
+		bo.Uint16(data[4:6]),
+	}
+	want := []uint16{1000, 1500, 1700}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sample %d: got %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestUndoHorizontalDifferencing16BitMultiSample(t *testing.T) {
+	bo := binary.LittleEndian
+	// 2 pixels wide, 4 samples per pixel (like RGBNIR).
+	// pixel0: R=100, G=200, B=300, N=400
+	// delta1: R=10, G=20, B=30, N=40
+	// Expected pixel1: 110, 220, 330, 440
+	data := make([]byte, 16)
+	bo.PutUint16(data[0:2], 100)
+	bo.PutUint16(data[2:4], 200)
+	bo.PutUint16(data[4:6], 300)
+	bo.PutUint16(data[6:8], 400)
+	bo.PutUint16(data[8:10], 10)
+	bo.PutUint16(data[10:12], 20)
+	bo.PutUint16(data[12:14], 30)
+	bo.PutUint16(data[14:16], 40)
+
+	undoHorizontalDifferencing(data, 2, 4, 2, bo)
+
+	want := []uint16{100, 200, 300, 400, 110, 220, 330, 440}
+	for i := 0; i < 8; i++ {
+		got := bo.Uint16(data[i*2 : i*2+2])
+		if got != want[i] {
+			t.Errorf("sample %d: got %d, want %d", i, got, want[i])
+		}
+	}
+}
+
+func TestBuildRescalerLinear(t *testing.T) {
+	fn := buildRescaler(RescaleLinear, 0, 65535)
+
+	tests := []struct {
+		in   uint16
+		want uint8
+	}{
+		{0, 0},
+		{65535, 255},
+		{32768, 128}, // ~128
+	}
+	for _, tt := range tests {
+		got := fn(tt.in)
+		if got != tt.want {
+			t.Errorf("linear(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestBuildRescalerLinearCustomRange(t *testing.T) {
+	fn := buildRescaler(RescaleLinear, 100, 10000)
+
+	// Below min → 0.
+	if got := fn(50); got != 0 {
+		t.Errorf("linear(50) = %d, want 0", got)
+	}
+	// Above max → 255.
+	if got := fn(20000); got != 255 {
+		t.Errorf("linear(20000) = %d, want 255", got)
+	}
+	// At min → 0.
+	if got := fn(100); got != 0 {
+		t.Errorf("linear(100) = %d, want 0", got)
+	}
+	// At max → 255.
+	if got := fn(10000); got != 255 {
+		t.Errorf("linear(10000) = %d, want 255", got)
+	}
+}
+
+func TestBuildRescalerLog(t *testing.T) {
+	fn := buildRescaler(RescaleLog, 1, 10000)
+
+	// At min → 0.
+	if got := fn(1); got != 0 {
+		t.Errorf("log(1) = %d, want 0", got)
+	}
+	// At max → 255.
+	if got := fn(10000); got != 255 {
+		t.Errorf("log(10000) = %d, want 255", got)
+	}
+	// Midpoint should be higher than linear midpoint (log curve).
+	mid := fn(5000)
+	linearMid := buildRescaler(RescaleLinear, 1, 10000)(5000)
+	if mid <= linearMid {
+		t.Errorf("log midpoint (%d) should be > linear midpoint (%d)", mid, linearMid)
+	}
+	// Below min → 0.
+	if got := fn(0); got != 0 {
+		t.Errorf("log(0) = %d, want 0", got)
+	}
+}
+
+func TestBuildRescalerNone(t *testing.T) {
+	fn := buildRescaler(RescaleNone, 0, 0)
+
+	if got := fn(42); got != 42 {
+		t.Errorf("none(42) = %d, want 42", got)
+	}
+	if got := fn(255); got != 255 {
+		t.Errorf("none(255) = %d, want 255", got)
+	}
+}
+
+func TestBuildRescalerEdgeCases(t *testing.T) {
+	// max == min → always 0.
+	fn := buildRescaler(RescaleLinear, 100, 100)
+	if got := fn(100); got != 0 {
+		t.Errorf("linear equal range: got %d, want 0", got)
+	}
+
+	fnLog := buildRescaler(RescaleLog, 100, 100)
+	if got := fnLog(100); got != 0 {
+		t.Errorf("log equal range: got %d, want 0", got)
+	}
+}
+
+func TestDecodeRawTile8BitBackwardsCompat(t *testing.T) {
+	// Verify that zero-value BandConfig produces identical output to the legacy code.
+	// 2x2 tile, 3 samples per pixel (RGB), 8-bit.
+	w, h, spp := 2, 2, 3
+	data := make([]byte, w*h*spp)
+	// pixel (0,0): R=255, G=0, B=0
+	data[0], data[1], data[2] = 255, 0, 0
+	// pixel (1,0): R=0, G=255, B=0
+	data[3], data[4], data[5] = 0, 255, 0
+	// pixel (0,1): R=0, G=0, B=255
+	data[6], data[7], data[8] = 0, 0, 255
+	// pixel (1,1): R=128, G=128, B=128
+	data[9], data[10], data[11] = 128, 128, 128
+
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: uint16(spp),
+		BitsPerSample:   []uint16{8, 8, 8},
+	}
+
+	r := &Reader{bo: binary.LittleEndian, ifds: []IFD{*ifd}}
+	img, err := r.decodeRawTile(ifd, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rgba := img.(*image.RGBA)
+	// Check pixel (0,0): R=255, G=0, B=0, A=255.
+	assertPixel(t, rgba, 0, 0, color.RGBA{255, 0, 0, 255})
+	// Check pixel (1,0): R=0, G=255, B=0, A=255.
+	assertPixel(t, rgba, 1, 0, color.RGBA{0, 255, 0, 255})
+	// Check pixel (0,1): R=0, G=0, B=255, A=255.
+	assertPixel(t, rgba, 0, 1, color.RGBA{0, 0, 255, 255})
+	// Check pixel (1,1): R=128, G=128, B=128, A=255.
+	assertPixel(t, rgba, 1, 1, color.RGBA{128, 128, 128, 255})
+}
+
+func TestDecodeRawTile8BitRGBA(t *testing.T) {
+	// 2x1 tile, 4 spp (RGBA), 8-bit, default BandConfig.
+	w, h, spp := 2, 1, 4
+	data := []byte{
+		10, 20, 30, 200, // pixel0: R=10, G=20, B=30, A=200
+		50, 60, 70, 0, // pixel1: transparent
+	}
+
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: uint16(spp),
+		BitsPerSample:   []uint16{8, 8, 8, 8},
+	}
+
+	r := &Reader{bo: binary.LittleEndian, ifds: []IFD{*ifd}}
+	img, err := r.decodeRawTile(ifd, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rgba := img.(*image.RGBA)
+	// pixel0: auto alpha from band 4 → A=200.
+	assertPixel(t, rgba, 0, 0, color.RGBA{10, 20, 30, 200})
+	// pixel1: alpha band=0 → transparent.
+	assertPixel(t, rgba, 1, 0, color.RGBA{0, 0, 0, 0})
+}
+
+func TestDecodeRawTile8BitSingleBandNodata(t *testing.T) {
+	// Single-band with nodata=0, zero-value BandConfig.
+	w, h, spp := 2, 1, 1
+	data := []byte{0, 42}
+
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: uint16(spp),
+		BitsPerSample:   []uint16{8},
+		NoData:          "0",
+	}
+
+	r := &Reader{bo: binary.LittleEndian, ifds: []IFD{*ifd}}
+	img, err := r.decodeRawTile(ifd, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rgba := img.(*image.RGBA)
+	// pixel0: nodata → transparent.
+	assertPixel(t, rgba, 0, 0, color.RGBA{0, 0, 0, 0})
+	// pixel1: value 42 → gray, opaque.
+	assertPixel(t, rgba, 1, 0, color.RGBA{42, 42, 42, 255})
+}
+
+func TestDecodeRawTile16BitBandReorder(t *testing.T) {
+	bo := binary.LittleEndian
+	// 2x1 tile, 4 spp (RGBNIR), 16-bit.
+	w, h, spp := 2, 1, 4
+	data := make([]byte, w*h*spp*2)
+
+	// pixel0: R=1000, G=2000, B=3000, NIR=5000
+	bo.PutUint16(data[0:2], 1000)
+	bo.PutUint16(data[2:4], 2000)
+	bo.PutUint16(data[4:6], 3000)
+	bo.PutUint16(data[6:8], 5000)
+	// pixel1: R=500, G=1500, B=2500, NIR=0 (transparent)
+	bo.PutUint16(data[8:10], 500)
+	bo.PutUint16(data[10:12], 1500)
+	bo.PutUint16(data[12:14], 2500)
+	bo.PutUint16(data[14:16], 0)
+
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: uint16(spp),
+		BitsPerSample:   []uint16{16, 16, 16, 16},
+	}
+
+	r := &Reader{
+		bo:   bo,
+		ifds: []IFD{*ifd},
+		bandCfg: BandConfig{
+			Bands:      [3]int{4, 1, 2}, // NIR, R, G → output R, G, B
+			AlphaBand:  -1,              // no alpha
+			Rescale:    RescaleLinear,
+			RescaleMin: 0,
+			RescaleMax: 10000,
+		},
+	}
+
+	img, err := r.decodeRawTile(ifd, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rgba := img.(*image.RGBA)
+
+	// pixel0: NIR=5000 → R=128, R=1000 → G=26, G=2000 → B=51.
+	rescale := buildRescaler(RescaleLinear, 0, 10000)
+	wantR := rescale(5000)
+	wantG := rescale(1000)
+	wantB := rescale(2000)
+	got := rgba.RGBAAt(0, 0)
+	if got.R != wantR || got.G != wantG || got.B != wantB || got.A != 255 {
+		t.Errorf("pixel(0,0) = %v, want R=%d G=%d B=%d A=255", got, wantR, wantG, wantB)
+	}
+
+	// pixel1: no alpha band → opaque.
+	got1 := rgba.RGBAAt(1, 0)
+	if got1.A != 255 {
+		t.Errorf("pixel(1,0) alpha = %d, want 255 (no alpha band)", got1.A)
+	}
+}
+
+func TestDecodeRawTile16BitWithAlphaBand(t *testing.T) {
+	bo := binary.LittleEndian
+	// 2x1 tile, 4 spp, 16-bit. Alpha band = 4.
+	w, h, spp := 2, 1, 4
+	data := make([]byte, w*h*spp*2)
+
+	// pixel0: R=1000, G=2000, B=3000, Alpha=8000
+	bo.PutUint16(data[0:2], 1000)
+	bo.PutUint16(data[2:4], 2000)
+	bo.PutUint16(data[4:6], 3000)
+	bo.PutUint16(data[6:8], 8000)
+	// pixel1: R=500, G=1500, B=2500, Alpha=0 (transparent)
+	bo.PutUint16(data[8:10], 500)
+	bo.PutUint16(data[10:12], 1500)
+	bo.PutUint16(data[12:14], 2500)
+	bo.PutUint16(data[14:16], 0)
+
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: uint16(spp),
+		BitsPerSample:   []uint16{16, 16, 16, 16},
+	}
+
+	r := &Reader{
+		bo:   bo,
+		ifds: []IFD{*ifd},
+		bandCfg: BandConfig{
+			Bands:      [3]int{1, 2, 3},
+			AlphaBand:  4,
+			Rescale:    RescaleLog,
+			RescaleMin: 1,
+			RescaleMax: 10000,
+		},
+	}
+
+	img, err := r.decodeRawTile(ifd, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rgba := img.(*image.RGBA)
+
+	// pixel0: alpha band = 8000 → rescaled to non-zero.
+	got0 := rgba.RGBAAt(0, 0)
+	if got0.A == 0 {
+		t.Error("pixel(0,0) alpha should be non-zero for source alpha=8000")
+	}
+	if got0.R == 0 && got0.G == 0 && got0.B == 0 {
+		t.Error("pixel(0,0) RGB should be non-zero")
+	}
+
+	// pixel1: alpha band = 0 → fully transparent.
+	got1 := rgba.RGBAAt(1, 0)
+	assertPixel(t, rgba, 1, 0, color.RGBA{0, 0, 0, 0})
+	_ = got1
+}
+
+func TestBuildRescalerLogCurveShape(t *testing.T) {
+	fn := buildRescaler(RescaleLog, 0, 10000)
+
+	// Log should give higher values at the low end compared to linear.
+	// Check that log(1000) > linear(1000).
+	logVal := fn(1000)
+	linVal := buildRescaler(RescaleLinear, 0, 10000)(1000)
+	if logVal <= linVal {
+		t.Errorf("log(1000)=%d should be > linear(1000)=%d for range 0-10000", logVal, linVal)
+	}
+
+	// Check monotonicity.
+	prev := fn(0)
+	for v := uint16(100); v <= 10000; v += 100 {
+		cur := fn(v)
+		if cur < prev {
+			t.Errorf("log not monotonic: log(%d)=%d < log(%d)=%d", v, cur, v-100, prev)
+		}
+		prev = cur
+	}
+}
+
+func TestIFDBytesPerSample(t *testing.T) {
+	ifd8 := IFD{BitsPerSample: []uint16{8}}
+	if got := ifd8.bytesPerSample(); got != 1 {
+		t.Errorf("8-bit: got %d, want 1", got)
+	}
+
+	ifd16 := IFD{BitsPerSample: []uint16{16, 16, 16, 16}}
+	if got := ifd16.bytesPerSample(); got != 2 {
+		t.Errorf("16-bit: got %d, want 2", got)
+	}
+
+	ifdEmpty := IFD{}
+	if got := ifdEmpty.bytesPerSample(); got != 1 {
+		t.Errorf("empty BitsPerSample: got %d, want 1", got)
+	}
+}
+
+func assertPixel(t *testing.T, img *image.RGBA, x, y int, want color.RGBA) {
+	t.Helper()
+	got := img.RGBAAt(x, y)
+	if got != want {
+		t.Errorf("pixel(%d,%d) = %v, want %v", x, y, got, want)
+	}
+}
+


### PR DESCRIPTION
## Summary

- **RGBNIR / uint16 GeoTIFF support**: Fix 16-bit horizontal differencing predictor (was reading 1 byte per sample, garbling deflate+predictor=2 uint16 files like ESA WorldCover S2 RGBNIR). Add `BandConfig` for band selection (`--bands`), alpha band control (`--alpha-band`), and linear/log rescaling from uint16→uint8 (`--rescale`, `--rescale-range`).
- **Explicit rescale range for 16-bit input**: Remove the auto-default of 0–65535 which produced near-black output on real satellite data (e.g. Sentinel-2 reflectance uses ~0–5700). Now 16-bit input requires explicit `--rescale-range` so users provide the correct range for their data.
- **Preset auto-detection from GeoTIFF metadata**: Parse GDAL_METADATA XML (tag 42112) to auto-configure processing — float data returns terrarium format preset, multi-band data with band descriptions returns band mapping and rescale range. Eliminates manual `--bands`/`--rescale-range` flags on satellite imagery with embedded metadata.

## Changes

- `internal/cog/reader.go` — 16-bit predictor fix, `BandConfig` struct, `SetBandConfig()`, `DetectPreset()`, GDAL metadata parsing
- `internal/cog/ifd.go` — GDAL_METADATA tag (42112) extraction
- `internal/cog/reader_test.go` — Comprehensive tests for predictor, band config, preset detection, GDAL metadata parsing
- `cmd/geotiff2pmtiles/main.go` — New CLI flags (`--bands`, `--alpha-band`, `--rescale`, `--rescale-range`, `--preset`), preset auto-detection integration
- `cmd/coginfo/main.go` — New debug tool for inspecting COG metadata
- Documentation updates: `ARCHITECTURE.md`, `DESIGN.md`, `README.md`, changelogs
