### PR TITLE
Fix auto min-zoom to guarantee single-tile coverage at minimum zoom

### DIFF
--- a/changes/2026-02-27-00-00-min-zoom-single-tile.md
+++ b/changes/2026-02-27-00-00-min-zoom-single-tile.md
@@ -1,0 +1,37 @@
+# Fix: Min zoom guarantees single-tile coverage
+
+## Problem
+
+The auto-detected minimum zoom used a fixed offset of `maxZoom - 6`, which did not
+guarantee that the entire image fit within a single tile at the minimum zoom level.
+For datasets where the natural "overview" tile is several levels below `maxZoom - 6`
+(e.g. small country-scale datasets), the minimum zoom was unnecessarily high and the
+image could still span multiple tiles.
+
+## Changes
+
+### `internal/coord/mercator.go`
+- Added `MinZoomForSingleTile(minLon, minLat, maxLon, maxLat float64) int`
+  Searches from zoom 1 upward and returns the highest zoom level at which all four
+  corners of the bounding box fall within the same tile. This is the highest zoom
+  where the full image is visible in a single tile without panning.
+
+### `cmd/geotiff2pmtiles/main.go`
+- Auto min-zoom now calls `coord.MinZoomForSingleTile` instead of `maxZoom - 6`.
+- Caps the result at `maxZoom` to avoid invalid ranges for point-like regions.
+
+### `internal/tile/zoom.go`
+- Updated `AutoZoomRange` signature to accept bounds `(minLon, minLat, maxLon, maxLat float64)`
+  and delegate to `MinZoomForSingleTile` for consistency.
+
+### `internal/coord/mercator_test.go`
+- Added `TestMinZoomForSingleTile` covering Switzerland, a tiny Zurich bounding box,
+  a degenerate point, the whole world, and the western hemisphere.
+  Each case verifies both the expected value and the invariant (single tile at returned
+  zoom, multiple tiles at zoom+1).
+
+## Example
+
+For a Switzerland dataset (lon 5.9–10.6°, lat 45.8–47.9°):
+- **Before**: `minZoom = maxZoom - 6 = 7` (image spans multiple tiles at zoom 7)
+- **After**: `minZoom = 6` (entire image fits in tile 33/22 at zoom 6)

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -236,9 +236,14 @@ func main() {
 		maxZoom = autoMax
 	}
 	if minZoom < 0 {
-		minZoom = maxZoom - 6
-		if minZoom < 0 {
-			minZoom = 0
+		// Use the highest zoom level at which the entire image fits in a single
+		// tile, so the output always has a useful overview at the minimum zoom.
+		minZoom = coord.MinZoomForSingleTile(
+			mergedBounds.MinLon, mergedBounds.MinLat,
+			mergedBounds.MaxLon, mergedBounds.MaxLat,
+		)
+		if minZoom > maxZoom {
+			minZoom = maxZoom
 		}
 	}
 	if verbose {

--- a/internal/coord/mercator.go
+++ b/internal/coord/mercator.go
@@ -167,6 +167,21 @@ func MaxZoomForResolution(pixelSizeMeters float64, centerLat float64, tileSize i
 	return iz
 }
 
+// MinZoomForSingleTile returns the highest zoom level at which all tiles
+// covering the given WGS84 bounding box fit within a single tile.
+// At this zoom level the entire image can be seen in one tile without panning.
+// Returns 0 if the bounds span multiple tiles even at zoom 1.
+func MinZoomForSingleTile(minLon, minLat, maxLon, maxLat float64) int {
+	for z := 1; z <= 28; z++ {
+		minTX, minTY := LonLatToTile(minLon, maxLat, z)
+		maxTX, maxTY := LonLatToTile(maxLon, minLat, z)
+		if minTX != maxTX || minTY != maxTY {
+			return z - 1
+		}
+	}
+	return 28 // extremely small or point region
+}
+
 // TilesInBounds returns all tile coordinates at the given zoom level that intersect the given WGS84 bounds.
 func TilesInBounds(zoom int, minLon, minLat, maxLon, maxLat float64) [][3]int {
 	minTX, minTY := LonLatToTile(minLon, maxLat, zoom) // note: maxLat -> minTY

--- a/internal/coord/mercator_test.go
+++ b/internal/coord/mercator_test.go
@@ -160,6 +160,56 @@ func TestMaxZoomForResolution(t *testing.T) {
 	}
 }
 
+func TestMinZoomForSingleTile(t *testing.T) {
+	tests := []struct {
+		name           string
+		minLon, minLat float64
+		maxLon, maxLat float64
+		wantZoom       int
+	}{
+		// Switzerland fits in a single tile at zoom 6.
+		{"switzerland", 5.9, 45.8, 10.6, 47.9, 6},
+		// A tiny 0.01° bounding box near Zurich fits in one tile at zoom 13.
+		{"zurich tiny", 8.54, 47.37, 8.55, 47.38, 13},
+		// A single-point region (degenerate box) should return zoom 28.
+		{"point zurich", 8.54, 47.37, 8.54, 47.37, 28},
+		// Whole-world bounds: single tile only at zoom 0.
+		{"world", -180, -85.05, 180, 85.05, 0},
+		// Western hemisphere spans 2 tiles at zoom 1, so single-tile zoom is 0.
+		{"western hemisphere", -180, -85.05, 0, 85.05, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MinZoomForSingleTile(tt.minLon, tt.minLat, tt.maxLon, tt.maxLat)
+			if got != tt.wantZoom {
+				t.Errorf("MinZoomForSingleTile(lon[%.2f,%.2f] lat[%.2f,%.2f]) = %d, want %d",
+					tt.minLon, tt.maxLon, tt.minLat, tt.maxLat, got, tt.wantZoom)
+			}
+			// Verify the result: bounds must fit in exactly one tile at the returned zoom.
+			if got >= 0 {
+				minTX, minTY := LonLatToTile(tt.minLon, tt.maxLat, got)
+				maxTX, maxTY := LonLatToTile(tt.maxLon, tt.minLat, got)
+				if minTX != maxTX || minTY != maxTY {
+					t.Errorf("at zoom %d, bounds span tiles (%d,%d)-(%d,%d), expected single tile",
+						got, minTX, minTY, maxTX, maxTY)
+				}
+			}
+			// Verify that one zoom level higher (if possible) spans multiple tiles
+			// (unless wantZoom==28 meaning the region is a point or extremely tiny).
+			if got < 28 {
+				z1 := got + 1
+				minTX, minTY := LonLatToTile(tt.minLon, tt.maxLat, z1)
+				maxTX, maxTY := LonLatToTile(tt.maxLon, tt.minLat, z1)
+				if minTX == maxTX && minTY == maxTY && tt.wantZoom != 28 {
+					t.Errorf("at zoom %d (one above), bounds still fit in a single tile — MinZoomForSingleTile should have returned %d",
+						z1, z1)
+				}
+			}
+		})
+	}
+}
+
 func TestTilesInBounds(t *testing.T) {
 	// A small bounding box around Zurich at zoom 10.
 	tiles := TilesInBounds(10, 8.4, 47.3, 8.6, 47.5)

--- a/internal/tile/zoom.go
+++ b/internal/tile/zoom.go
@@ -6,11 +6,14 @@ import (
 
 // AutoZoomRange computes appropriate min/max zoom levels based on source data.
 // pixelSizeMeters is the source ground resolution in meters.
-func AutoZoomRange(pixelSizeMeters float64, centerLat float64, tileSize int) (minZoom, maxZoom int) {
+// The min zoom is the highest zoom level at which the entire image fits in a
+// single tile, so the output always has a useful overview.
+func AutoZoomRange(pixelSizeMeters float64, centerLat float64, tileSize int,
+	minLon, minLat, maxLon, maxLat float64) (minZoom, maxZoom int) {
 	maxZoom = coord.MaxZoomForResolution(pixelSizeMeters, centerLat, tileSize)
-	minZoom = maxZoom - 6
-	if minZoom < 0 {
-		minZoom = 0
+	minZoom = coord.MinZoomForSingleTile(minLon, minLat, maxLon, maxLat)
+	if minZoom > maxZoom {
+		minZoom = maxZoom
 	}
 	return
 }


### PR DESCRIPTION
Replace the fixed `maxZoom - 6` offset with `MinZoomForSingleTile`, a new coord function that finds the highest zoom level at which the entire bounding box fits within a single tile. This ensures the PMTiles output always has a useful whole-image overview tile at the minimum zoom level.