### PR TITLE
Add nodata support to BandConfig with --nodata flag and multi-band/16-bit transparency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@ positions within bounds that have no data.
 - Continuous disk spilling via dedicated I/O goroutine with configurable memory backpressure (auto ~90% of RAM)
 - Uniform tiles (single color) stored as 4 bytes, never spilled to disk
 - `sync.Pool` for `*image.RGBA` buffers: render, downsample, and decode paths reuse 256 KB buffers instead of allocating/GC'ing per tile
-- Single-band nodata pixels decoded as transparent (alpha=0) so resampling/downsampling automatically excludes them
+- Nodata pixels (all bands equal to GDAL_NODATA tag value) decoded as transparent (alpha=0) for single-band and multi-band/16-bit data; stored in `BandConfig.HasNodata`/`Nodata`, auto-detected from GeoTIFF, overridable with `--nodata`
 - Source fallthrough on nodata: transparent (alpha=0) samples are skipped and the next source is tried, preventing holes in one source from blocking valid data in another
 - PMTiles writer uses temp file for tile data (only directory entries in memory)
 - Pyramid downsampling avoids redundant source reads for lower zoom levels

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -75,16 +75,24 @@ calls, at ~3.25s cumulative CPU it was still worth eliminating.
 
 ## Nodata handling for image (non-float) data
 
-For single-band GeoTIFF data (e.g. ESA WorldCover land cover classifications), pixels
-matching the GDAL_NODATA value are decoded as transparent (alpha=0) instead of opaque
-black (alpha=255). This is handled in `decodeRawTile` by parsing the nodata string
-from the first IFD and comparing each pixel against it. Only applied for spp≤2
-(single-band and gray+alpha) since multi-band nodata semantics are more complex.
-The nodata value must be an integer in [0, 255] to qualify. This ensures all downstream
-code (resampling, downsampling, encoding) automatically treats nodata areas as
-transparent — bilinear/Lanczos/bicubic already exclude alpha=0 pixels from RGB
-interpolation, and `sampleFromTileSources` skips fully transparent results to try the
-next source (see below).
+Pixels matching the GDAL_NODATA value are decoded as transparent (alpha=0) so downstream
+resampling, downsampling, and encoding automatically treat them as empty.
+
+**Legacy path** (spp≤2, 8-bit, default BandConfig): nodata parsed from the GDAL_NODATA
+tag (IFD field, integer in [0,255]); single-band sets alpha=0 for matching pixels,
+gray+alpha also overrides the alpha channel.
+
+**General path** (multi-band or 16-bit, including presets): nodata is stored in
+`BandConfig.HasNodata`/`BandConfig.Nodata`. `DetectPreset()` automatically populates
+these from the GDAL_NODATA tag (integer in [0,65535]) so the preset is self-contained.
+The `--nodata` CLI flag overrides the auto-detected value. In the pixel loop, all `spp`
+file bands are compared to the raw nodata value before rescaling; if all match, the pixel
+is emitted as (0,0,0,0). Only applied when there is no dedicated alpha band
+(`effectiveAlpha < 0`), since an alpha band already encodes transparency directly.
+
+All downstream code (bilinear/Lanczos/bicubic resampling, mode downsampling,
+`sampleFromTileSources`) excludes alpha=0 pixels from interpolation and voting, and
+tries the next source on fully-transparent results (see below).
 
 ## Nodata-aware source fallthrough
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--alpha-band`  | `auto`        | Alpha band: `auto` (band 4 for 8-bit spp>=4), `-1` (none), or 1-indexed band |
 | `--rescale`     | `auto`        | Rescale mode: `auto`, `linear`, `log`, `none` (auto requires `--rescale-range` for 16-bit) |
 | `--rescale-range` |             | Input value range `min,max` for rescaling (required for 16-bit data) |
+| `--nodata`      |               | Nodata value: pixels with all bands equal to this integer are transparent (auto-detected from GeoTIFF if not set) |
 | `--verbose`     | `false`       | Verbose progress output                            |
 | `--version`     |               | Print version and exit                             |
 | `--cpuprofile`  |               | Write CPU profile to file                          |

--- a/changes/2026-02-27-nodata-bandconfig.md
+++ b/changes/2026-02-27-nodata-bandconfig.md
@@ -1,0 +1,50 @@
+# 2026-02-27: Nodata in BandConfig — multi-band transparency and --nodata flag
+
+## Problem
+
+Nodata values were only applied in the legacy single-band 8-bit path (spp≤2, default
+BandConfig). Multi-band and 16-bit files (e.g. ESA Worldcover RGBNIR uint16 nodata=0)
+had their nodata pixels decoded as opaque black/RGB instead of transparent (alpha=0).
+The GDAL_NODATA tag (42113) was already parsed into `IFD.NoData` but not used in the
+general decode path.
+
+## Changes
+
+### `internal/cog/reader.go`
+
+- **`BandConfig`**: added `HasNodata bool` and `Nodata float64` fields. When set,
+  pixels where all file bands equal the raw nodata value are decoded as transparent
+  (alpha=0) before rescaling. Valid when HasNodata is true.
+- **`BandConfig.String()`**: new method returning a human-readable summary including
+  bands, rescale range, and nodata value. Used in log output.
+- **`DetectPreset()`**: populates `cfg.HasNodata`/`cfg.Nodata` from the GeoTIFF
+  GDAL_NODATA tag so the returned preset is self-contained.
+- **`decodeRawTile()` general path**: parses nodata from `cfg.HasNodata`/`cfg.Nodata`
+  (preset/override) or falls back to `r.ifds[0].NoData`. In the pixel loop, checks
+  all `spp` file bands against the nodata value. If all match, the pixel is emitted
+  as (0,0,0,0). Only applied when `effectiveAlpha < 0` (no dedicated alpha band).
+
+### `cmd/geotiff2pmtiles/main.go`
+
+- **`--nodata`** flag: overrides the auto-detected nodata value. Must be a non-negative
+  integer ≤ 65535.
+- **Nodata logic** (after `parseBandConfig`): CLI `--nodata` takes precedence; if not
+  set and preset didn't supply a value, auto-detects from `sources[0].NoData()`.
+- **`log.Printf("Band config: %s", bandCfg)`**: always logged after the config is
+  finalized, showing bands, rescale, and nodata so users can verify the active config.
+- Auto-detected preset log updated to use `BandConfig.String()`.
+
+### `integration/satellite_esaworldcover_test.go`
+
+- `TestESAWorldCoverPreset`: added assertions for `HasNodata=true` and `Nodata=0`.
+
+## Behavior
+
+For ESA Worldcover RGBNIR (uint16, 4 bands, nodata=0):
+- Auto-detected preset now includes `HasNodata=true, Nodata=0`
+- Pixels with all four bands = 0 are decoded as transparent
+- Log shows: `Auto-detected: multispectral-rgbnir (bands 1,2,3, rescale linear [0, 10000], nodata 0)`
+- Then: `Band config: bands 1,2,3, rescale linear [0, 10000], nodata 0`
+
+For SWIR (uint8, nodata=255): nodata is auto-detected from the GeoTIFF tag; pixels
+with all bands = 255 become transparent.

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -50,6 +50,7 @@ func main() {
 		alphaBandStr string
 		rescaleStr   string
 		rescaleRange string
+		nodataStr    string
 	)
 
 	flag.StringVar(&format, "format", "jpeg", "Tile encoding: jpeg, png, webp, terrarium")
@@ -72,6 +73,7 @@ func main() {
 	flag.StringVar(&alphaBandStr, "alpha-band", "auto", "1-indexed band for alpha (0=auto: band 4 for 8-bit spp>=4; -1=force no alpha)")
 	flag.StringVar(&rescaleStr, "rescale", "auto", "Rescale mode: auto, log, linear, none (auto: requires --rescale-range for 16-bit)")
 	flag.StringVar(&rescaleRange, "rescale-range", "", "Input value range for rescaling: min,max (required for 16-bit data)")
+	flag.StringVar(&nodataStr, "nodata", "", "Nodata value: pixels with all bands equal to this integer are transparent (auto-detected from GeoTIFF if not set)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>\n\n")
@@ -218,6 +220,26 @@ func main() {
 	if err != nil {
 		log.Fatalf("Band config: %v", err)
 	}
+
+	// Apply nodata: CLI override takes precedence, then preset/IFD auto-detection.
+	if nodataStr != "" {
+		v, err := strconv.ParseFloat(strings.TrimSpace(nodataStr), 64)
+		if err != nil || v < 0 || v > 65535 || v != math.Floor(v) {
+			log.Fatalf("--nodata: must be a non-negative integer ≤ 65535, got %q", nodataStr)
+		}
+		bandCfg.HasNodata = true
+		bandCfg.Nodata = v
+	} else if !bandCfg.HasNodata {
+		// Auto-detect from the first source file if not already set by preset.
+		if nd := sources[0].NoData(); nd != "" {
+			if v, err := strconv.ParseFloat(strings.TrimSpace(nd), 64); err == nil && v >= 0 && v <= 65535 && v == math.Floor(v) {
+				bandCfg.HasNodata = true
+				bandCfg.Nodata = v
+			}
+		}
+	}
+
+	log.Printf("Band config: %s", bandCfg)
 	for _, src := range sources {
 		src.SetBandConfig(bandCfg)
 	}
@@ -559,10 +581,7 @@ func parseBandConfig(bandsStr, alphaBandStr, rescaleStr, rescaleRange string, fi
 			if rescaleRange == "" {
 				// Try auto-detection from GDAL metadata before erroring.
 				if preset, ok := firstSrc.DetectPreset(); ok && !bandsExplicit {
-					log.Printf("Auto-detected: %s (bands %d,%d,%d, rescale linear [%.0f, %.0f])",
-						preset.Name,
-						preset.BandCfg.Bands[0], preset.BandCfg.Bands[1], preset.BandCfg.Bands[2],
-						preset.BandCfg.RescaleMin, preset.BandCfg.RescaleMax)
+					log.Printf("Auto-detected: %s (%s)", preset.Name, preset.BandCfg)
 					return preset.BandCfg, nil
 				}
 				return cfg, fmt.Errorf("16-bit GeoTIFF detected: --rescale-range min,max is required\n" +

--- a/integration/satellite_esaworldcover_test.go
+++ b/integration/satellite_esaworldcover_test.go
@@ -59,6 +59,12 @@ func TestESAWorldCoverPreset(t *testing.T) {
 	if preset.BandCfg.RescaleMin != 0 {
 		t.Errorf("rescale min = %.0f, want 0", preset.BandCfg.RescaleMin)
 	}
+	if !preset.BandCfg.HasNodata {
+		t.Error("expected HasNodata to be true")
+	}
+	if preset.BandCfg.Nodata != 0 {
+		t.Errorf("nodata = %.0f, want 0", preset.BandCfg.Nodata)
+	}
 }
 
 // TestESAWorldCoverPipeline runs the full GeoTIFF→PMTiles pipeline on the

--- a/internal/cog/reader.go
+++ b/internal/cog/reader.go
@@ -26,7 +26,7 @@ const (
 	RescaleLog                       // Logarithmic mapping from [min,max] → [0,255]
 )
 
-// BandConfig controls band selection, alpha handling, and rescaling for multi-band GeoTIFFs.
+// BandConfig controls band selection, alpha handling, rescaling, and nodata for multi-band GeoTIFFs.
 // Zero value produces identical behavior to the legacy code path (bands 1,2,3; auto alpha for spp≥4; no rescaling).
 type BandConfig struct {
 	Bands      [3]int      // 1-indexed input band → R,G,B output. Zero value = default (1,2,3)
@@ -34,6 +34,31 @@ type BandConfig struct {
 	Rescale    RescaleMode // Rescaling mode
 	RescaleMin float64     // Input value range minimum
 	RescaleMax float64     // Input value range maximum
+	HasNodata  bool        // if true, pixels with all bands == Nodata are decoded as transparent (alpha=0)
+	Nodata     float64     // raw (pre-rescale) nodata value; valid when HasNodata is true
+}
+
+// String returns a human-readable summary of the band configuration.
+func (cfg BandConfig) String() string {
+	bands := cfg.Bands
+	if bands == ([3]int{}) {
+		bands = [3]int{1, 2, 3}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "bands %d,%d,%d", bands[0], bands[1], bands[2])
+	switch cfg.Rescale {
+	case RescaleLinear:
+		fmt.Fprintf(&b, ", rescale linear [%.0f, %.0f]", cfg.RescaleMin, cfg.RescaleMax)
+	case RescaleLog:
+		fmt.Fprintf(&b, ", rescale log [%.0f, %.0f]", cfg.RescaleMin, cfg.RescaleMax)
+	}
+	if cfg.AlphaBand > 0 {
+		fmt.Fprintf(&b, ", alpha band %d", cfg.AlphaBand)
+	}
+	if cfg.HasNodata {
+		fmt.Fprintf(&b, ", nodata %.0f", cfg.Nodata)
+	}
+	return b.String()
 }
 
 // Bounds represents geographic bounds in WGS84.
@@ -724,6 +749,22 @@ func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 		}
 	}
 
+	// General-path nodata: prefer BandConfig, fall back to IFD tag.
+	// Used for multi-band or 16-bit data not handled by the legacy path.
+	var genHasNodata bool
+	var genNodataU16 uint16
+	if !useLegacyNodata {
+		if cfg.HasNodata {
+			genHasNodata = true
+			genNodataU16 = uint16(cfg.Nodata)
+		} else if nd := r.ifds[0].NoData; nd != "" {
+			if v, err := strconv.ParseFloat(strings.TrimSpace(nd), 64); err == nil && v >= 0 && v <= 65535 && v == math.Floor(v) {
+				genHasNodata = true
+				genNodataU16 = uint16(v)
+			}
+		}
+	}
+
 	// Build rescaler. For 16-bit data with no explicit rescaling (e.g. coginfo
 	// or debug tools using zero-value BandConfig), fall back to linear 0-65535
 	// so values are at least visible rather than uint8-truncated.
@@ -797,6 +838,26 @@ func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 			}
 			if spp > 2 && bandB < spp {
 				bV = readSample(pixelOff, bandB)
+			}
+
+			// Nodata check: if all file bands equal the nodata value, emit transparent.
+			// Only applies when there is no explicit alpha band (alpha=0 already handles
+			// transparency for files with an alpha channel).
+			if genHasNodata && effectiveAlpha < 0 {
+				isNodata := true
+				for b := 0; b < spp; b++ {
+					if readSample(pixelOff, b) != genNodataU16 {
+						isNodata = false
+						break
+					}
+				}
+				if isNodata {
+					pix[pixIdx+0] = 0
+					pix[pixIdx+1] = 0
+					pix[pixIdx+2] = 0
+					pix[pixIdx+3] = 0
+					continue
+				}
 			}
 
 			// Alpha.
@@ -1457,6 +1518,14 @@ func (r *Reader) DetectPreset() (Preset, bool) {
 		Rescale:    RescaleLinear,
 		RescaleMin: rescaleMin,
 		RescaleMax: rescaleMax,
+	}
+
+	// Include nodata from the GeoTIFF tag so the preset is self-contained.
+	if nd := r.ifds[0].NoData; nd != "" {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(nd), 64); err == nil && v >= 0 && v <= 65535 && v == math.Floor(v) {
+			cfg.HasNodata = true
+			cfg.Nodata = v
+		}
 	}
 
 	return Preset{Name: name, BandCfg: cfg}, true


### PR DESCRIPTION
- BandConfig gains HasNodata+Nodata fields; pixels where all file bands equal the raw nodata value are decoded as transparent (alpha=0) before rescaling
- BandConfig.String() added for human-readable log output including nodata
- DetectPreset() auto-populates HasNodata/Nodata from GDAL_NODATA tag (42113) so presets are self-contained and carry the correct nodata value
- decodeRawTile() general path now applies nodata for multi-band and 16-bit data (previously only the legacy spp≤2/8-bit path handled nodata)
- --nodata CLI flag added to geotiff2pmtiles for explicit override
- Nodata auto-detected from GeoTIFF tag when not set by preset or CLI flag
- Band config always logged after finalisation: "Band config: bands 1,2,3, ..."