### PR TITLE
Optimize tile throughput, add benchmarks and unit tests

### DIFF
--- a/changes/2026-02-27-16-19-performance-optimizations.md
+++ b/changes/2026-02-27-16-19-performance-optimizations.md
@@ -1,0 +1,100 @@
+# Performance Optimizations
+
+## Summary
+
+Five targeted optimizations improve tile generation throughput across all
+example datasets. All changes are measured by the existing benchmark suite
+(`go test ./internal/tile/ -bench=. -benchmem`).
+
+## Changes
+
+### 1. Eliminate per-pixel `IFDTileSize()` call in resampling (`resample.go`)
+
+`bilinearSampleCached`, `nearestSampleCached`, and `readPixelCached` each
+called `src.IFDTileSize(level)` on every output pixel to obtain the source
+tile dimensions. The values are constant for all pixels within a tile and were
+already precomputed in the `tileSource` struct by `prepareTileSources`.
+
+**Fix:** Added `tw, th int` parameters to all three functions and updated
+`sampleFromTileSources` to pass `src.tileW` / `src.tileH` directly, removing
+the redundant IFD slice lookup from the hot per-pixel path.
+
+### 2. Pool `lons`/`lats` slices in `renderTile` and `renderTileTerrarium` (`resample.go`)
+
+Both render functions allocated two `[]float64` slices (one for longitudes, one
+for latitudes) per tile via `make`. For 512-pixel tiles these are 4 KB each;
+across thousands of max-zoom tiles the repeated allocation and zero-init added
+measurable GC pressure.
+
+**Fix:** Added a `sync.Pool` (`lonLatPool`) that recycles a single backing
+`[]float64` of length `2×tileSize` (lons in the first half, lats in the second)
+across consecutive tile renders. The pool is keyed by length so it degrades
+gracefully if tile size varies.
+
+### 3. Direct Pix slice access in RGBA downsample quadrant functions (`downsample.go`)
+
+`downsampleQuadrantBilinear`, `downsampleQuadrantNearest`, and
+`downsampleQuadrantMode` read source pixels via `srcPixel()` (which calls
+`image.RGBAAt` — including a bounds check) and wrote results via `SetRGBA`
+(another bounds check). For a 512×512 tile the inner loop makes 65,536 such
+calls per quadrant.
+
+**Fix:** Replaced all `srcPixel`/`SetRGBA` calls with direct index arithmetic
+on `src.Pix` and `dst.Pix`. The bounds clamps inside `srcPixel` are provably
+unnecessary: with `half = tileSize/2`, the source coordinates `sx = 2*dx` and
+`sy = 2*dy` satisfy `sx+1 ≤ tileSize−1` and `sy+1 ≤ tileSize−1` for all loop
+iterations. Eliminated coordinates are documented inline.
+
+**Benchmark results (256×256 tiles, Apple M1 Max):**
+
+| Benchmark | Before | After | Speedup |
+|-----------|--------|-------|---------|
+| `Downsample_RGBAChildren_Nearest` | 334 µs | 116 µs | **2.9×** |
+| `Downsample_RGBAChildren_Bilinear` | 1,270 µs | 366 µs | **3.47×** |
+
+The gray fast-path (`downsampleQuadrantGray*`) was already using direct slice
+access and is unchanged.
+
+### 4. `detectUniform` uses uint64 word comparison (`tiledata.go`)
+
+The previous implementation compared four bytes individually per 4-byte pixel.
+For a 512×512 solid-color tile (1 MB of pixel data) this required 1,048,572
+individual byte comparisons.
+
+**Fix:** Packs the reference pixel into a `uint32` and reads 8 bytes at a time
+using `binary.LittleEndian.Uint64`, making one integer comparison per two
+pixels. A single-iteration `uint32` cleanup handles the last 4-byte group when
+the slice length is not a multiple of 8.
+
+**Benchmark results (256×256 solid tile):**
+
+| Benchmark | Before | After | Speedup |
+|-----------|--------|-------|---------|
+| `DetectUniform_Solid` | 93 µs | 29 µs | **3.25×** |
+| `NewTileData_Uniform` | 94 µs | 29 µs | **3.3×** |
+
+Non-uniform tiles exit on the first mismatch (≤ 8 bytes read) — unchanged.
+
+### 5. Fill-color tile encoding cache and shared fill tile (`generator.go`)
+
+When `--fill-color` is set and many tiles have no source coverage (e.g.,
+sparse datasets or large bounding boxes), the uniform fill tile was
+re-encoded by `cfg.Encoder.Encode` for every such tile. For PNG/WebP this
+is measurably expensive. Separately, `newTileDataUniform` was called once per
+nil child in the downsample loop, creating small but unnecessary allocations.
+
+**Fix:**
+- Pre-encode the fill-color tile once before the zoom loop and cache the
+  resulting `[]byte` (`fillColorCached`).
+- In the worker loop, uniform fill-color tiles bypass `Encode` and use the
+  cached bytes directly for `WriteTile`. The PMTiles writer's FNV-64a
+  deduplication ensures the bytes are stored on disk only once regardless.
+- Reuse a single shared `*TileData` instance (`fillTileShared`) as the
+  substitute for nil children during downsampling, eliminating one allocation
+  per nil child per tile.
+
+## No behavioral changes
+
+All optimizations are purely mechanical — same output, same resampling
+semantics. The full test suite (`go test ./... -count=1`) passes without
+modification.

--- a/changes/2026-02-27-17-30-missing-performance-benchmarks.md
+++ b/changes/2026-02-27-17-30-missing-performance-benchmarks.md
@@ -1,0 +1,79 @@
+# Missing Performance Benchmarks
+
+Added comprehensive performance benchmarks covering all previously unguarded hot paths.
+
+## Files changed
+
+- `internal/tile/bench_test.go` — extended with 20 new benchmarks
+- `internal/cog/bench_test.go` — new file (5 benchmarks)
+- `internal/coord/bench_test.go` — new file (7 benchmarks)
+- `internal/pmtiles/bench_test.go` — new file (6 benchmarks)
+- `internal/encode/bench_test.go` — new file (8 benchmarks)
+
+## New benchmarks by category
+
+### Downsample modes (tile package)
+
+Previously only `Nearest` and `Bilinear` were benchmarked. Added:
+
+- `BenchmarkDownsample_GrayChildren_{Lanczos,Bicubic,Mode}`
+- `BenchmarkDownsample_RGBAChildren_{Lanczos,Bicubic,Mode}`
+- `BenchmarkDownsample_TerrariumChildren_{Nearest,Bilinear,Lanczos}`
+
+`Lanczos` is the high-quality default and the most expensive path (~3-12 ms/tile).
+`Terrarium` downsample was entirely unrepresented.
+
+### LUT vs direct computation (tile package)
+
+The Lanczos-3 and bicubic LUT tables are a key design pattern (eliminates
+`math.Sin` calls, was 7.56% of CPU). Now guarded against regression:
+
+- `BenchmarkLanczos3LUT` / `BenchmarkLanczos3Direct`
+- `BenchmarkBicubicLUT` / `BenchmarkBicubicDirect`
+
+At 1 iteration: LUT ~83 ns vs direct ~333 ns (4× speedup for Lanczos).
+
+### RGBA pool (tile package)
+
+`GetRGBA`/`PutRGBA` is on the critical path for every tile rendered and every
+downsample step. `BenchmarkGetPutRGBA` measures the round-trip cost.
+
+### Missing completion variants (tile package)
+
+- `BenchmarkMemoryBytes_{RGBA,Uniform}` — only Gray was benchmarked
+- `BenchmarkDeserialize_Uniform` — missing from the deserialize group
+
+### TileCache (cog package)
+
+The sharded LRU cache is inside the per-pixel sampling loop. A previous
+optimization eliminated string keys that consumed 18% of CPU. Now covered:
+
+- `BenchmarkTileKeyHash` — FNV-1a integer hash for shard selection
+- `BenchmarkTileCache_GetHit` — read lock cache hit (dominant path)
+- `BenchmarkTileCache_GetMiss` — cache miss (cold start / eviction)
+- `BenchmarkTileCache_Put` — unique tile insertion
+- `BenchmarkTileCache_PutDuplicate` — dedup early-return path
+
+### Coordinate functions (coord package)
+
+- `BenchmarkPixelToLonLat` — called 2×tileSize per tile in `renderTile`
+- `BenchmarkLonLatToTile` — tile coordinate lookup
+- `BenchmarkTileBounds` — tile-to-WGS84 bounds computation
+- `BenchmarkSortTilesByHilbert_{Z6,Z8,Z10}` — Hilbert batch sort at 3 scales
+- `BenchmarkResolutionAtLat` — per-tile resolution for overview selection
+
+### PMTiles directory (pmtiles package)
+
+- `BenchmarkZXYToTileID` — Hilbert tile ID, called for every tile written
+- `BenchmarkBuildDirectory_{Small,Medium,Large}` — root-only / leaf-split paths
+- `BenchmarkOptimizeRunLengths` — run-length merging step
+- `BenchmarkTileHash` — FNV-64a hash for tile deduplication
+
+### Encoders (encode package)
+
+Previously zero benchmarks. Added:
+
+- `BenchmarkPNGEncode` / `BenchmarkPNGEncode_Gray`
+- `BenchmarkJPEGEncode_{Q85,Q75}`
+- `BenchmarkTerrariumEncode`
+- `BenchmarkElevationToTerrarium` / `BenchmarkTerrariumToElevation`

--- a/internal/cog/bench_test.go
+++ b/internal/cog/bench_test.go
@@ -1,0 +1,95 @@
+package cog
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+// --- tileKeyHash benchmarks ---
+
+// BenchmarkTileKeyHash measures the FNV-1a inspired hash used for shard
+// selection on every TileCache.Get and TileCache.Put call. This is on the
+// inner per-pixel sampling loop.
+func BenchmarkTileKeyHash(b *testing.B) {
+	keys := [4]tileKey{
+		{id: 1, level: 0, col: 100, row: 200},
+		{id: 2, level: 3, col: 512, row: 300},
+		{id: 1, level: 1, col: 0, row: 0},
+		{id: 3, level: 5, col: 1024, row: 768},
+	}
+	var sink uint64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += tileKeyHash(keys[i&3])
+	}
+	_ = sink
+}
+
+// --- TileCache benchmarks ---
+
+// solidRGBA returns a tileSize×tileSize RGBA image filled with a single color.
+func solidRGBA(tileSize int, c color.RGBA) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	pix := img.Pix
+	for i := 0; i < len(pix); i += 4 {
+		pix[i] = c.R
+		pix[i+1] = c.G
+		pix[i+2] = c.B
+		pix[i+3] = c.A
+	}
+	return img
+}
+
+// BenchmarkTileCache_GetHit measures a cache hit — the dominant case during
+// tile rendering when the LRU warms up. Uses a read lock, so multiple
+// goroutines can share the cache without serialization.
+func BenchmarkTileCache_GetHit(b *testing.B) {
+	cache := NewTileCache(256)
+	img := solidRGBA(256, color.RGBA{100, 150, 200, 255})
+	cache.Put(1, 0, 10, 20, img)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.Get(1, 0, 10, 20)
+	}
+}
+
+// BenchmarkTileCache_GetMiss measures a cache miss — the path taken before
+// the cache is warm, or when a tile is evicted. Falls through to a nil return.
+func BenchmarkTileCache_GetMiss(b *testing.B) {
+	cache := NewTileCache(256)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Use varying coordinates so we don't accidentally hit a cached entry.
+		_ = cache.Get(1, 0, i%1024, (i/1024)%1024)
+	}
+}
+
+// BenchmarkTileCache_Put measures inserting unique tiles. Each iteration uses
+// distinct coordinates so no early-return deduplication is triggered.
+func BenchmarkTileCache_Put(b *testing.B) {
+	// Use a large cache so eviction doesn't dominate.
+	cache := NewTileCache(b.N + 64)
+	img := solidRGBA(256, color.RGBA{100, 150, 200, 255})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Put(1, 0, i%8192, (i/8192)%8192, img)
+	}
+}
+
+// BenchmarkTileCache_PutDuplicate measures inserting the same key repeatedly.
+// The implementation returns immediately on duplicate, so this exercises the
+// hot dedup path (read lock → map lookup → early return).
+func BenchmarkTileCache_PutDuplicate(b *testing.B) {
+	cache := NewTileCache(256)
+	img := solidRGBA(256, color.RGBA{100, 150, 200, 255})
+	cache.Put(1, 0, 5, 5, img)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Put(1, 0, 5, 5, img)
+	}
+}

--- a/internal/coord/bench_test.go
+++ b/internal/coord/bench_test.go
@@ -1,0 +1,123 @@
+package coord
+
+import "testing"
+
+// --- PixelToLonLat benchmark ---
+
+// BenchmarkPixelToLonLat measures the per-row latitude computation in
+// renderTile. Called tileSize times per tile to precompute the lat array
+// (the key O(n) trig optimization over the naive O(n²) approach).
+func BenchmarkPixelToLonLat(b *testing.B) {
+	z, tx, ty, tileSize := 10, 535, 358, 256
+	var sinkLon, sinkLat float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		px := float64(i%tileSize) + 0.5
+		py := float64(i%tileSize) + 0.5
+		lon, lat := PixelToLonLat(z, tx, ty, tileSize, px, py)
+		sinkLon += lon
+		sinkLat += lat
+	}
+	_, _ = sinkLon, sinkLat
+}
+
+// --- LonLatToTile benchmark ---
+
+// BenchmarkLonLatToTile measures tile coordinate lookup, used during bounds
+// computation and zoom-level inference.
+func BenchmarkLonLatToTile(b *testing.B) {
+	coords := [4][2]float64{
+		{8.5417, 47.3769},  // Zurich
+		{-74.0060, 40.713}, // New York
+		{139.69, 35.689},   // Tokyo
+		{2.3522, 48.856},   // Paris
+	}
+	var sinkX, sinkY int
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := coords[i&3]
+		x, y := LonLatToTile(c[0], c[1], 14)
+		sinkX += x
+		sinkY += y
+	}
+	_, _ = sinkX, sinkY
+}
+
+// --- TileBounds benchmark ---
+
+// BenchmarkTileBounds measures the inverse tile-to-WGS84 bounds computation,
+// called once per output tile in renderTile to determine the CRS bounding box.
+func BenchmarkTileBounds(b *testing.B) {
+	var sinkA, sinkB float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		x := i % 16384
+		y := (i / 16384) % 16384
+		minLon, minLat, _, _ := TileBounds(14, x, y)
+		sinkA += minLon
+		sinkB += minLat
+	}
+	_, _ = sinkA, sinkB
+}
+
+// --- SortTilesByHilbert benchmarks ---
+
+// makeTileList builds a slice of [3]int tiles covering all tiles at zoom z.
+func makeTileList(z int) [][3]int {
+	n := 1 << uint(z)
+	tiles := make([][3]int, 0, n*n)
+	for y := 0; y < n; y++ {
+		for x := 0; x < n; x++ {
+			tiles = append(tiles, [3]int{z, x, y})
+		}
+	}
+	return tiles
+}
+
+// BenchmarkSortTilesByHilbert_Z8 measures sorting 256×256 = 65536 tiles.
+// This is a realistic zoom-level batch size for a moderate-resolution dataset.
+func BenchmarkSortTilesByHilbert_Z8(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// Rebuild the slice each iteration so we sort an unsorted list.
+		b.StopTimer()
+		tiles := makeTileList(8)
+		b.StartTimer()
+		SortTilesByHilbert(tiles)
+	}
+}
+
+// BenchmarkSortTilesByHilbert_Z10 measures sorting 1024×1024 = 1M tiles.
+// Representative of a high-resolution global dataset at z10.
+func BenchmarkSortTilesByHilbert_Z10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tiles := makeTileList(10)
+		b.StartTimer()
+		SortTilesByHilbert(tiles)
+	}
+}
+
+// BenchmarkSortTilesByHilbert_Z6 measures sorting 4096 tiles.
+// Representative of a small regional dataset or a single zoom batch.
+func BenchmarkSortTilesByHilbert_Z6(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tiles := makeTileList(6)
+		b.StartTimer()
+		SortTilesByHilbert(tiles)
+	}
+}
+
+// --- ResolutionAtLat benchmark ---
+
+// BenchmarkResolutionAtLat measures the per-tile resolution calculation
+// called in renderTile to select the correct COG overview level.
+func BenchmarkResolutionAtLat(b *testing.B) {
+	lats := [4]float64{0, 30, 47.37, 60}
+	var sink float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += ResolutionAtLat(lats[i&3], 14, 256)
+	}
+	_ = sink
+}

--- a/internal/encode/bench_test.go
+++ b/internal/encode/bench_test.go
@@ -1,0 +1,143 @@
+package encode
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+// gradientImage creates a tileSize×tileSize RGBA image with a smooth gradient.
+// Used for PNG and JPEG encode benchmarks where a natural-looking image matters.
+func gradientImage(tileSize int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			img.SetRGBA(x, y, color.RGBA{
+				R: uint8(x % 256),
+				G: uint8(y % 256),
+				B: uint8((x + y) % 256),
+				A: 255,
+			})
+		}
+	}
+	return img
+}
+
+// terrariumImage creates a tileSize×tileSize RGBA image with Terrarium-encoded
+// elevation values, simulating typical DEM tile content.
+func terrariumImage(tileSize int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			// Elevation from -100 m to +2900 m, varying by position.
+			elev := float64(x+y)/float64(2*tileSize)*3000.0 - 100.0
+			c := ElevationToTerrarium(elev)
+			img.SetRGBA(x, y, c)
+		}
+	}
+	return img
+}
+
+// --- PNG encode benchmarks ---
+
+// BenchmarkPNGEncode measures PNG encoding of a full-color gradient tile.
+// PNG is the default output format and is used for every tile in the archive.
+func BenchmarkPNGEncode(b *testing.B) {
+	enc := &PNGEncoder{}
+	img := gradientImage(256)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = enc.Encode(img)
+	}
+}
+
+// BenchmarkPNGEncode_Gray measures PNG encoding of a gray (single-channel)
+// image, which is the common case for classification rasters.
+func BenchmarkPNGEncode_Gray(b *testing.B) {
+	enc := &PNGEncoder{}
+	// Build a gray RGBA image (R=G=B, A=255).
+	img := image.NewRGBA(image.Rect(0, 0, 256, 256))
+	for y := 0; y < 256; y++ {
+		for x := 0; x < 256; x++ {
+			v := uint8((x + y) % 256)
+			img.SetRGBA(x, y, color.RGBA{v, v, v, 255})
+		}
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = enc.Encode(img)
+	}
+}
+
+// --- JPEG encode benchmarks ---
+
+// BenchmarkJPEGEncode_Q85 measures JPEG encoding at quality 85, the default
+// for satellite imagery tiles.
+func BenchmarkJPEGEncode_Q85(b *testing.B) {
+	enc := &JPEGEncoder{Quality: 85}
+	img := gradientImage(256)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = enc.Encode(img)
+	}
+}
+
+// BenchmarkJPEGEncode_Q75 measures JPEG encoding at quality 75 for comparison.
+func BenchmarkJPEGEncode_Q75(b *testing.B) {
+	enc := &JPEGEncoder{Quality: 75}
+	img := gradientImage(256)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = enc.Encode(img)
+	}
+}
+
+// --- Terrarium encode/decode benchmarks ---
+
+// BenchmarkTerrariumEncode measures PNG encoding of a Terrarium-format tile.
+// Terrarium tiles contain pre-encoded elevation data, so the encode step is
+// just PNG compression of the RGB values.
+func BenchmarkTerrariumEncode(b *testing.B) {
+	enc := &TerrariumEncoder{}
+	img := terrariumImage(256)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = enc.Encode(img)
+	}
+}
+
+// BenchmarkElevationToTerrarium measures the per-pixel elevation→RGB
+// conversion called when writing each Terrarium tile pixel.
+func BenchmarkElevationToTerrarium(b *testing.B) {
+	elevations := [8]float64{0, 100, -50, 1500, 3000, -100, 500, 2500}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ElevationToTerrarium(elevations[i&7])
+	}
+}
+
+// BenchmarkTerrariumToElevation measures the per-pixel RGB→elevation
+// decoding called in the Terrarium-aware downsample path.
+func BenchmarkTerrariumToElevation(b *testing.B) {
+	pixels := [8]color.RGBA{
+		ElevationToTerrarium(0),
+		ElevationToTerrarium(100),
+		ElevationToTerrarium(-50),
+		ElevationToTerrarium(1500),
+		ElevationToTerrarium(3000),
+		ElevationToTerrarium(-100),
+		ElevationToTerrarium(500),
+		ElevationToTerrarium(2500),
+	}
+	var sink float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += TerrariumToElevation(pixels[i&7])
+	}
+	_ = sink
+}

--- a/internal/pmtiles/bench_test.go
+++ b/internal/pmtiles/bench_test.go
@@ -1,0 +1,105 @@
+package pmtiles
+
+import "testing"
+
+// --- ZXYToTileID benchmark ---
+
+// BenchmarkZXYToTileID measures the Hilbert-curve tile ID computation called
+// for every tile written by the PMTiles writer.
+func BenchmarkZXYToTileID(b *testing.B) {
+	// Use realistic z14 tile coordinates (Zurich area).
+	coords := [4][3]int{
+		{14, 8590, 5747},
+		{14, 8591, 5748},
+		{14, 8589, 5746},
+		{14, 8592, 5749},
+	}
+	var sink uint64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := coords[i&3]
+		sink += ZXYToTileID(c[0], c[1], c[2])
+	}
+	_ = sink
+}
+
+// makeEntries builds a slice of N sequential entries with contiguous offsets.
+// The tile IDs are taken from a realistic z10 Hilbert ordering.
+func makeEntries(n int) []Entry {
+	entries := make([]Entry, n)
+	offset := uint64(0)
+	tileSize := uint32(5000) // ~5 KB per tile, typical JPEG
+	for i := 0; i < n; i++ {
+		x := i % 1024
+		y := (i / 1024) % 1024
+		entries[i] = Entry{
+			TileID:    ZXYToTileID(10, x, y),
+			Offset:    offset,
+			Length:    tileSize,
+			RunLength: 1,
+		}
+		offset += uint64(tileSize)
+	}
+	return entries
+}
+
+// BenchmarkBuildDirectory_Small measures directory building for a small tileset
+// (≤16K entries) that fits entirely in the root directory without leaf splits.
+func BenchmarkBuildDirectory_Small(b *testing.B) {
+	entries := makeEntries(1000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = buildDirectory(entries)
+	}
+}
+
+// BenchmarkBuildDirectory_Medium measures directory building for a medium
+// tileset (~16K entries) at the threshold where leaf dirs may be created.
+func BenchmarkBuildDirectory_Medium(b *testing.B) {
+	entries := makeEntries(16384)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = buildDirectory(entries)
+	}
+}
+
+// BenchmarkBuildDirectory_Large measures directory building for a large tileset
+// (~65K entries) that requires leaf directory partitioning.
+func BenchmarkBuildDirectory_Large(b *testing.B) {
+	entries := makeEntries(65536)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = buildDirectory(entries)
+	}
+}
+
+// BenchmarkOptimizeRunLengths measures the run-length merging step in
+// directory building, which collapses consecutive same-length tiles.
+func BenchmarkOptimizeRunLengths(b *testing.B) {
+	// Mix of mergeable and non-mergeable entries.
+	entries := makeEntries(10000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = optimizeRunLengths(entries)
+	}
+}
+
+// BenchmarkTileHash measures the FNV-64a hash used for tile deduplication.
+// Called for every WriteTile invocation.
+func BenchmarkTileHash(b *testing.B) {
+	// Simulate a typical 5 KB encoded tile.
+	data := make([]byte, 5000)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	var sink uint64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += tileHash(data)
+	}
+	_ = sink
+}

--- a/internal/tile/bench_test.go
+++ b/internal/tile/bench_test.go
@@ -438,3 +438,285 @@ func BenchmarkAsImage_Uniform(b *testing.B) {
 		td.AsImage()
 	}
 }
+
+// --- Missing MemoryBytes variants ---
+
+func BenchmarkMemoryBytes_RGBA(b *testing.B) {
+	img := rgbaCheckerImage(256)
+	td := newTileData(img, 256)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		td.MemoryBytes()
+	}
+}
+
+func BenchmarkMemoryBytes_Uniform(b *testing.B) {
+	td := newTileDataUniform(color.RGBA{42, 42, 42, 255}, 256)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		td.MemoryBytes()
+	}
+}
+
+// --- Missing Deserialize variant ---
+
+func BenchmarkDeserialize_Uniform(b *testing.B) {
+	td := newTileDataUniform(color.RGBA{42, 42, 42, 255}, 256)
+	buf, typ := td.SerializeAppend(nil)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		DeserializeTileData(buf, typ, 256)
+	}
+}
+
+// --- Downsample benchmarks: missing modes ---
+
+func BenchmarkDownsample_GrayChildren_Lanczos(b *testing.B) {
+	tileSize := 256
+	img1 := grayCheckerImage(tileSize, 50, 150)
+	img2 := grayCheckerImage(tileSize, 100, 200)
+	tl := newTileData(img1, tileSize)
+	tr := newTileData(img2, tileSize)
+	bl := newTileData(img1, tileSize)
+	br := newTileData(img2, tileSize)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTile(tl, tr, bl, br, tileSize, ResamplingLanczos)
+	}
+}
+
+func BenchmarkDownsample_GrayChildren_Bicubic(b *testing.B) {
+	tileSize := 256
+	img1 := grayCheckerImage(tileSize, 50, 150)
+	img2 := grayCheckerImage(tileSize, 100, 200)
+	tl := newTileData(img1, tileSize)
+	tr := newTileData(img2, tileSize)
+	bl := newTileData(img1, tileSize)
+	br := newTileData(img2, tileSize)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTile(tl, tr, bl, br, tileSize, ResamplingBicubic)
+	}
+}
+
+func BenchmarkDownsample_GrayChildren_Mode(b *testing.B) {
+	tileSize := 256
+	img1 := grayCheckerImage(tileSize, 50, 150)
+	img2 := grayCheckerImage(tileSize, 100, 200)
+	tl := newTileData(img1, tileSize)
+	tr := newTileData(img2, tileSize)
+	bl := newTileData(img1, tileSize)
+	br := newTileData(img2, tileSize)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTile(tl, tr, bl, br, tileSize, ResamplingMode)
+	}
+}
+
+func BenchmarkDownsample_RGBAChildren_Lanczos(b *testing.B) {
+	tileSize := 256
+	c1 := color.RGBA{255, 0, 0, 255}
+	c2 := color.RGBA{0, 255, 0, 255}
+	img1 := checkerImage(tileSize, c1, c2)
+	img2 := checkerImage(tileSize, c2, c1)
+	tl := newTileData(img1, tileSize)
+	tr := newTileData(img2, tileSize)
+	bl := newTileData(img1, tileSize)
+	br := newTileData(img2, tileSize)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTile(tl, tr, bl, br, tileSize, ResamplingLanczos)
+	}
+}
+
+func BenchmarkDownsample_RGBAChildren_Bicubic(b *testing.B) {
+	tileSize := 256
+	c1 := color.RGBA{255, 0, 0, 255}
+	c2 := color.RGBA{0, 255, 0, 255}
+	img1 := checkerImage(tileSize, c1, c2)
+	img2 := checkerImage(tileSize, c2, c1)
+	tl := newTileData(img1, tileSize)
+	tr := newTileData(img2, tileSize)
+	bl := newTileData(img1, tileSize)
+	br := newTileData(img2, tileSize)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTile(tl, tr, bl, br, tileSize, ResamplingBicubic)
+	}
+}
+
+func BenchmarkDownsample_RGBAChildren_Mode(b *testing.B) {
+	tileSize := 256
+	c1 := color.RGBA{255, 0, 0, 255}
+	c2 := color.RGBA{0, 255, 0, 255}
+	img1 := checkerImage(tileSize, c1, c2)
+	img2 := checkerImage(tileSize, c2, c1)
+	tl := newTileData(img1, tileSize)
+	tr := newTileData(img2, tileSize)
+	bl := newTileData(img1, tileSize)
+	br := newTileData(img2, tileSize)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTile(tl, tr, bl, br, tileSize, ResamplingMode)
+	}
+}
+
+// terrariumCheckerImage creates a 256×256 RGBA image where each pixel encodes
+// alternating elevation values using the Terrarium RGB scheme. Used to exercise
+// the Terrarium-aware downsample path.
+func terrariumCheckerImage(tileSize int, elev1, elev2 float64) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			elev := elev1
+			if (x+y)%2 == 1 {
+				elev = elev2
+			}
+			c := elevationToTerrariumRGBA(elev)
+			img.SetRGBA(x, y, c)
+		}
+	}
+	return img
+}
+
+// elevationToTerrariumRGBA converts an elevation to a Terrarium-encoded RGBA
+// pixel inline, avoiding an import cycle with the encode package in bench_test.go.
+func elevationToTerrariumRGBA(elev float64) color.RGBA {
+	value := elev + 32768.0
+	if value < 0 {
+		value = 0
+	}
+	if value > 65535.996 {
+		value = 65535.996
+	}
+	r := int(value / 256)
+	if r > 255 {
+		r = 255
+	}
+	rem := value - float64(r)*256.0
+	g := int(rem)
+	if g > 255 {
+		g = 255
+	}
+	bl := int((rem - float64(g)) * 256.0)
+	if bl > 255 {
+		bl = 255
+	}
+	return color.RGBA{R: uint8(r), G: uint8(g), B: uint8(bl), A: 255}
+}
+
+func BenchmarkDownsample_TerrariumChildren_Bilinear(b *testing.B) {
+	tileSize := 256
+	img1 := terrariumCheckerImage(tileSize, 100.0, 200.0)
+	img2 := terrariumCheckerImage(tileSize, 300.0, 400.0)
+	tl := &TileData{img: img1, tileSize: tileSize}
+	tr := &TileData{img: img2, tileSize: tileSize}
+	bl := &TileData{img: img1, tileSize: tileSize}
+	br := &TileData{img: img2, tileSize: tileSize}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTileTerrarium(tl, tr, bl, br, tileSize, ResamplingBilinear)
+	}
+}
+
+func BenchmarkDownsample_TerrariumChildren_Lanczos(b *testing.B) {
+	tileSize := 256
+	img1 := terrariumCheckerImage(tileSize, 100.0, 200.0)
+	img2 := terrariumCheckerImage(tileSize, 300.0, 400.0)
+	tl := &TileData{img: img1, tileSize: tileSize}
+	tr := &TileData{img: img2, tileSize: tileSize}
+	bl := &TileData{img: img1, tileSize: tileSize}
+	br := &TileData{img: img2, tileSize: tileSize}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTileTerrarium(tl, tr, bl, br, tileSize, ResamplingLanczos)
+	}
+}
+
+func BenchmarkDownsample_TerrariumChildren_Nearest(b *testing.B) {
+	tileSize := 256
+	img1 := terrariumCheckerImage(tileSize, 100.0, 200.0)
+	img2 := terrariumCheckerImage(tileSize, 300.0, 400.0)
+	tl := &TileData{img: img1, tileSize: tileSize}
+	tr := &TileData{img: img2, tileSize: tileSize}
+	bl := &TileData{img: img1, tileSize: tileSize}
+	br := &TileData{img: img2, tileSize: tileSize}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		downsampleTileTerrarium(tl, tr, bl, br, tileSize, ResamplingNearest)
+	}
+}
+
+// --- LUT benchmarks: validate the LUT optimization vs direct computation ---
+
+// BenchmarkLanczos3LUT measures the LUT lookup path used in the hot
+// lanczosSampleCached inner loop. Expected to be ~7× faster than direct.
+func BenchmarkLanczos3LUT(b *testing.B) {
+	xs := [8]float64{0.1, 0.5, 1.0, 1.5, 2.0, 2.5, 2.9, 0.0}
+	var sink float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += lanczos3LUT(xs[i&7])
+	}
+	_ = sink
+}
+
+// BenchmarkLanczos3Direct measures the direct computation (math.Sin) used
+// as a baseline to validate the LUT speedup.
+func BenchmarkLanczos3Direct(b *testing.B) {
+	xs := [8]float64{0.1, 0.5, 1.0, 1.5, 2.0, 2.5, 2.9, 0.0}
+	var sink float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += lanczos3(xs[i&7])
+	}
+	_ = sink
+}
+
+// BenchmarkBicubicLUT measures the bicubic LUT lookup path.
+func BenchmarkBicubicLUT(b *testing.B) {
+	xs := [8]float64{0.1, 0.5, 1.0, 1.5, 1.9, 0.3, 0.7, 1.2}
+	var sink float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += bicubicLUT(xs[i&7])
+	}
+	_ = sink
+}
+
+// BenchmarkBicubicDirect measures the direct bicubic polynomial computation.
+func BenchmarkBicubicDirect(b *testing.B) {
+	xs := [8]float64{0.1, 0.5, 1.0, 1.5, 1.9, 0.3, 0.7, 1.2}
+	var sink float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += bicubic(xs[i&7])
+	}
+	_ = sink
+}
+
+// --- RGBA pool benchmarks ---
+
+// BenchmarkGetPutRGBA measures pool throughput for 256×256 images.
+// This is on the critical path for every tile rendered and every downsample step.
+func BenchmarkGetPutRGBA(b *testing.B) {
+	// Warm the pool with one image so the first Get doesn't allocate.
+	img := GetRGBA(256, 256)
+	PutRGBA(img)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		img = GetRGBA(256, 256)
+		PutRGBA(img)
+	}
+}

--- a/internal/tile/diskstore_test.go
+++ b/internal/tile/diskstore_test.go
@@ -1,0 +1,298 @@
+package tile
+
+import (
+	"image/color"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/pspoerri/geotiff2pmtiles/internal/encode"
+)
+
+// encodePNG encodes a TileData as PNG bytes for use in store tests.
+func encodePNG(t *testing.T, td *TileData) []byte {
+	t.Helper()
+	enc := &encode.PNGEncoder{}
+	data, err := enc.Encode(td.AsImage())
+	if err != nil {
+		t.Fatalf("encodePNG: %v", err)
+	}
+	return data
+}
+
+// --- Basic Put/Get ---
+
+func TestDiskTileStore_PutGet_Uniform(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	c := color.RGBA{255, 0, 0, 255}
+	td := newTileDataUniform(c, 4)
+	store.Put(1, 2, 3, td, nil)
+
+	got := store.Get(1, 2, 3)
+	if got == nil {
+		t.Fatal("expected non-nil for stored uniform tile")
+	}
+	if !got.IsUniform() {
+		t.Error("expected uniform tile back")
+	}
+	if got.Color() != c {
+		t.Errorf("color = %v, want %v", got.Color(), c)
+	}
+}
+
+func TestDiskTileStore_PutGet_NonUniform(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	img := checkerImage(4, color.RGBA{255, 0, 0, 255}, color.RGBA{0, 0, 255, 255})
+	td := newTileData(img, 4)
+	encoded := encodePNG(t, td)
+	store.Put(2, 5, 7, td, encoded)
+
+	got := store.Get(2, 5, 7)
+	if got == nil {
+		t.Fatal("expected non-nil for stored non-uniform tile")
+	}
+}
+
+func TestDiskTileStore_GetMissing(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4})
+	defer store.Close()
+
+	if got := store.Get(0, 0, 0); got != nil {
+		t.Errorf("expected nil for missing tile, got %T", got)
+	}
+}
+
+// --- Len ---
+
+func TestDiskTileStore_Len(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	if l := store.Len(); l != 0 {
+		t.Errorf("initial Len = %d, want 0", l)
+	}
+
+	// Uniform tile.
+	store.Put(0, 0, 0, newTileDataUniform(color.RGBA{255, 0, 0, 255}, 4), nil)
+	if l := store.Len(); l != 1 {
+		t.Errorf("Len after 1 put = %d, want 1", l)
+	}
+
+	// Non-uniform tile.
+	img := grayCheckerImage(4, 50, 100)
+	td := newTileData(img, 4)
+	store.Put(0, 1, 0, td, encodePNG(t, td))
+	if l := store.Len(); l != 2 {
+		t.Errorf("Len after 2 puts = %d, want 2", l)
+	}
+}
+
+// --- Disk spill ---
+
+func TestDiskTileStore_DiskSpill_PutGetRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// MemoryLimitBytes > 0 enables the I/O goroutine and disk spilling.
+	// Use a large-enough value so that mapOverhead (64 bytes/tile) never
+	// permanently triggers backpressure for our small test set.
+	store := NewDiskTileStore(DiskTileStoreConfig{
+		TileSize:         4,
+		TempDir:          dir,
+		MemoryLimitBytes: 1024 * 1024, // 1 MB: enables spilling, no deadlock
+		Format:           "png",
+	})
+	defer store.Close()
+
+	img := grayCheckerImage(4, 100, 200)
+	td := newTileData(img, 4)
+	encoded := encodePNG(t, td)
+
+	const nTiles = 20
+	for i := 0; i < nTiles; i++ {
+		store.Put(5, i, 0, td, encoded)
+	}
+	store.Drain()
+
+	for i := 0; i < nTiles; i++ {
+		if got := store.Get(5, i, 0); got == nil {
+			t.Errorf("tile (5,%d,0) missing after drain", i)
+		}
+	}
+}
+
+func TestDiskTileStore_DiskSpill_TempFileCreated(t *testing.T) {
+	dir := t.TempDir()
+
+	store := NewDiskTileStore(DiskTileStoreConfig{
+		TileSize:         4,
+		TempDir:          dir,
+		MemoryLimitBytes: 1024 * 1024,
+		Format:           "png",
+	})
+	defer store.Close()
+
+	// Before any spill, temp file should not exist.
+	if p := store.TempFilePath(); p != "" {
+		t.Errorf("TempFilePath before any write = %q, want empty", p)
+	}
+
+	img := grayCheckerImage(4, 10, 20)
+	td := newTileData(img, 4)
+	store.Put(1, 0, 0, td, encodePNG(t, td))
+	store.Drain()
+
+	if p := store.TempFilePath(); p == "" {
+		t.Error("TempFilePath after disk write should be non-empty")
+	}
+}
+
+// --- Close removes temp file ---
+
+func TestDiskTileStore_Close_RemovesTempFile(t *testing.T) {
+	dir := t.TempDir()
+
+	store := NewDiskTileStore(DiskTileStoreConfig{
+		TileSize:         4,
+		TempDir:          dir,
+		MemoryLimitBytes: 1024 * 1024,
+		Format:           "png",
+	})
+
+	img := grayCheckerImage(4, 10, 20)
+	td := newTileData(img, 4)
+	store.Put(1, 0, 0, td, encodePNG(t, td))
+	store.Drain()
+
+	path := store.TempFilePath()
+	if path == "" {
+		t.Fatal("expected temp file to have been created")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("temp file missing before Close: %v", err)
+	}
+
+	store.Close()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("temp file still exists after Close (err=%v)", err)
+	}
+}
+
+// --- TempFilePath with no spill ---
+
+func TestDiskTileStore_TempFilePath_NoSpill(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	if p := store.TempFilePath(); p != "" {
+		t.Errorf("TempFilePath for no-spill store = %q, want empty", p)
+	}
+}
+
+// --- Drain idempotency ---
+
+func TestDiskTileStore_Drain_Idempotent(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{
+		TileSize:         4,
+		MemoryLimitBytes: 1024 * 1024,
+		Format:           "png",
+	})
+	defer store.Close()
+
+	img := grayCheckerImage(4, 1, 2)
+	td := newTileData(img, 4)
+	store.Put(0, 0, 0, td, encodePNG(t, td))
+
+	// Multiple Drain calls must not panic or deadlock.
+	store.Drain()
+	store.Drain()
+	store.Drain()
+}
+
+// --- Stats ---
+
+func TestDiskTileStore_Stats_ReturnsNonEmpty(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	store.Put(0, 0, 0, newTileDataUniform(color.RGBA{100, 0, 0, 255}, 4), nil)
+	s := store.Stats()
+	if s == "" {
+		t.Error("Stats() returned empty string")
+	}
+}
+
+// --- MemoryBytes ---
+
+func TestDiskTileStore_MemoryBytes_IncreasesAfterPut(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	before := store.MemoryBytes()
+	store.Put(0, 0, 0, newTileDataUniform(color.RGBA{100, 0, 0, 255}, 4), nil)
+	after := store.MemoryBytes()
+
+	if after <= before {
+		t.Errorf("MemoryBytes should increase after Put: before=%d after=%d", before, after)
+	}
+}
+
+// --- Concurrent Put ---
+
+func TestDiskTileStore_ConcurrentPut(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{
+		InitialCapacity: 100,
+		TileSize:        4,
+		Format:          "png",
+	})
+	defer store.Close()
+
+	img := grayCheckerImage(4, 50, 150)
+	td := newTileData(img, 4)
+	encoded := encodePNG(t, td)
+
+	const nGoroutines = 20
+	var wg sync.WaitGroup
+	for i := 0; i < nGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			store.Put(7, idx, 0, td, encoded)
+		}(i)
+	}
+	wg.Wait()
+
+	if l := store.Len(); l != nGoroutines {
+		t.Errorf("Len after concurrent puts = %d, want %d", l, nGoroutines)
+	}
+}
+
+// --- Multiple uniform tiles with different keys ---
+
+func TestDiskTileStore_MultipleUniforms_SeparateKeys(t *testing.T) {
+	store := NewDiskTileStore(DiskTileStoreConfig{TileSize: 4, Format: "png"})
+	defer store.Close()
+
+	colors := []color.RGBA{
+		{255, 0, 0, 255},
+		{0, 255, 0, 255},
+		{0, 0, 255, 255},
+	}
+	for i, c := range colors {
+		store.Put(0, i, 0, newTileDataUniform(c, 4), nil)
+	}
+
+	for i, want := range colors {
+		got := store.Get(0, i, 0)
+		if got == nil {
+			t.Fatalf("tile (0,%d,0) missing", i)
+		}
+		if got.Color() != want {
+			t.Errorf("tile (0,%d,0): color=%v want=%v", i, got.Color(), want)
+		}
+	}
+}

--- a/internal/tile/downsample.go
+++ b/internal/tile/downsample.go
@@ -637,35 +637,59 @@ func downsampleQuadrantTerrariumBicubic(dst *image.RGBA, src *image.RGBA, dstOff
 // produce each output pixel. This is equivalent to bilinear downsampling.
 // Pixels with alpha == 0 are treated as nodata and excluded from RGB averaging
 // so they don't bleed dark colors into the result.
+//
+// Uses direct Pix slice access to avoid image.RGBAAt/SetRGBA bounds checks.
+// Clamping is omitted: for half = tileSize/2, sx+1 = 2*dx+1 ≤ tileSize-1 and
+// sy+1 = 2*dy+1 ≤ tileSize-1, so all coordinates are always within bounds.
 func downsampleQuadrantBilinear(dst *image.RGBA, src *image.RGBA, dstOffX, dstOffY, half, tileSize int) {
+	srcPix := src.Pix
+	dstPix := dst.Pix
+	srcStride := src.Stride
+	dstStride := dst.Stride
 	for dy := 0; dy < half; dy++ {
+		srcRow0 := (dy * 2) * srcStride
+		srcRow1 := (dy*2 + 1) * srcStride
+		dstRowOff := (dstOffY + dy) * dstStride
 		for dx := 0; dx < half; dx++ {
-			// Map destination pixel to a 2x2 block in the source.
-			sx := dx * 2
-			sy := dy * 2
+			sx4 := dx * 8 // sx=dx*2, sx*4=dx*8
+			off00 := srcRow0 + sx4
+			off10 := off00 + 4
+			off01 := srcRow1 + sx4
+			off11 := off01 + 4
 
-			// Read the 2x2 source block, clamping to source bounds.
-			p00 := srcPixel(src, sx, sy, tileSize)
-			p10 := srcPixel(src, sx+1, sy, tileSize)
-			p01 := srcPixel(src, sx, sy+1, tileSize)
-			p11 := srcPixel(src, sx+1, sy+1, tileSize)
-
-			pixels := [4]color.RGBA{p00, p10, p01, p11}
+			a00 := srcPix[off00+3]
+			a10 := srcPix[off10+3]
+			a01 := srcPix[off01+3]
+			a11 := srcPix[off11+3]
 
 			// Alpha: straight average of all 4 (nodata contributes 0).
-			aSum := uint16(p00.A) + uint16(p10.A) + uint16(p01.A) + uint16(p11.A)
-			a := (aSum + 2) / 4
+			a := uint8((uint16(a00)+uint16(a10)+uint16(a01)+uint16(a11)+2) / 4)
 
 			// RGB: average only pixels with non-zero alpha.
 			var rSum, gSum, bSum uint16
 			var count uint16
-			for _, p := range pixels {
-				if p.A == 0 {
-					continue
-				}
-				rSum += uint16(p.R)
-				gSum += uint16(p.G)
-				bSum += uint16(p.B)
+			if a00 != 0 {
+				rSum += uint16(srcPix[off00])
+				gSum += uint16(srcPix[off00+1])
+				bSum += uint16(srcPix[off00+2])
+				count++
+			}
+			if a10 != 0 {
+				rSum += uint16(srcPix[off10])
+				gSum += uint16(srcPix[off10+1])
+				bSum += uint16(srcPix[off10+2])
+				count++
+			}
+			if a01 != 0 {
+				rSum += uint16(srcPix[off01])
+				gSum += uint16(srcPix[off01+1])
+				bSum += uint16(srcPix[off01+2])
+				count++
+			}
+			if a11 != 0 {
+				rSum += uint16(srcPix[off11])
+				gSum += uint16(srcPix[off11+1])
+				bSum += uint16(srcPix[off11+2])
 				count++
 			}
 
@@ -673,13 +697,11 @@ func downsampleQuadrantBilinear(dst *image.RGBA, src *image.RGBA, dstOffX, dstOf
 				continue // all nodata — leave transparent
 			}
 
-			r := (rSum + count/2) / count
-			g := (gSum + count/2) / count
-			b := (bSum + count/2) / count
-
-			dst.SetRGBA(dstOffX+dx, dstOffY+dy, color.RGBA{
-				R: uint8(r), G: uint8(g), B: uint8(b), A: uint8(a),
-			})
+			dstOff := dstRowOff + (dstOffX+dx)*4
+			dstPix[dstOff] = uint8((rSum + count/2) / count)
+			dstPix[dstOff+1] = uint8((gSum + count/2) / count)
+			dstPix[dstOff+2] = uint8((bSum + count/2) / count)
+			dstPix[dstOff+3] = a
 		}
 	}
 }
@@ -803,18 +825,35 @@ func downsampleQuadrantBicubic(dst *image.RGBA, src *image.RGBA, dstOffX, dstOff
 // source block. Ties are broken by taking the first value encountered
 // (top-left bias). Designed for categorical/classified rasters where
 // interpolated values are meaningless.
+//
+// Uses direct Pix slice access to avoid image.RGBAAt/SetRGBA bounds checks.
 func downsampleQuadrantMode(dst *image.RGBA, src *image.RGBA, dstOffX, dstOffY, half, tileSize int) {
+	srcPix := src.Pix
+	dstPix := dst.Pix
+	srcStride := src.Stride
+	dstStride := dst.Stride
 	for dy := 0; dy < half; dy++ {
+		srcRow0 := (dy * 2) * srcStride
+		srcRow1 := (dy*2 + 1) * srcStride
+		dstRowOff := (dstOffY + dy) * dstStride
 		for dx := 0; dx < half; dx++ {
-			sx := dx * 2
-			sy := dy * 2
+			sx4 := dx * 8
+			off00 := srcRow0 + sx4
+			off10 := off00 + 4
+			off01 := srcRow1 + sx4
+			off11 := off01 + 4
 
-			p00 := srcPixel(src, sx, sy, tileSize)
-			p10 := srcPixel(src, sx+1, sy, tileSize)
-			p01 := srcPixel(src, sx, sy+1, tileSize)
-			p11 := srcPixel(src, sx+1, sy+1, tileSize)
+			p00 := color.RGBA{srcPix[off00], srcPix[off00+1], srcPix[off00+2], srcPix[off00+3]}
+			p10 := color.RGBA{srcPix[off10], srcPix[off10+1], srcPix[off10+2], srcPix[off10+3]}
+			p01 := color.RGBA{srcPix[off01], srcPix[off01+1], srcPix[off01+2], srcPix[off01+3]}
+			p11 := color.RGBA{srcPix[off11], srcPix[off11+1], srcPix[off11+2], srcPix[off11+3]}
 
-			dst.SetRGBA(dstOffX+dx, dstOffY+dy, modeRGBA(p00, p10, p01, p11))
+			result := modeRGBA(p00, p10, p01, p11)
+			dstOff := dstRowOff + (dstOffX+dx)*4
+			dstPix[dstOff] = result.R
+			dstPix[dstOff+1] = result.G
+			dstPix[dstOff+2] = result.B
+			dstPix[dstOff+3] = result.A
 		}
 	}
 }
@@ -862,13 +901,25 @@ func modeRGBA(a, b, c, d color.RGBA) color.RGBA {
 }
 
 // downsampleQuadrantNearest picks the top-left pixel from each 2x2 block.
+// Uses direct Pix slice access to avoid image.RGBAAt bounds checks and
+// SetRGBA bounds checks. Clamping is omitted: for half = tileSize/2, sx =
+// 2*dx ≤ tileSize-2 and sy = 2*dy ≤ tileSize-2, so coordinates are always
+// within bounds.
 func downsampleQuadrantNearest(dst *image.RGBA, src *image.RGBA, dstOffX, dstOffY, half, tileSize int) {
+	srcPix := src.Pix
+	dstPix := dst.Pix
+	srcStride := src.Stride
+	dstStride := dst.Stride
 	for dy := 0; dy < half; dy++ {
+		srcRowOff := (dy * 2) * srcStride
+		dstRowOff := (dstOffY + dy) * dstStride
 		for dx := 0; dx < half; dx++ {
-			sx := dx * 2
-			sy := dy * 2
-			p := srcPixel(src, sx, sy, tileSize)
-			dst.SetRGBA(dstOffX+dx, dstOffY+dy, p)
+			srcOff := srcRowOff + dx*8 // sx=dx*2, sx*4=dx*8
+			dstOff := dstRowOff + (dstOffX+dx)*4
+			dstPix[dstOff] = srcPix[srcOff]
+			dstPix[dstOff+1] = srcPix[srcOff+1]
+			dstPix[dstOff+2] = srcPix[srcOff+2]
+			dstPix[dstOff+3] = srcPix[srcOff+3]
 		}
 	}
 }

--- a/internal/tile/downsample.go
+++ b/internal/tile/downsample.go
@@ -663,7 +663,7 @@ func downsampleQuadrantBilinear(dst *image.RGBA, src *image.RGBA, dstOffX, dstOf
 			a11 := srcPix[off11+3]
 
 			// Alpha: straight average of all 4 (nodata contributes 0).
-			a := uint8((uint16(a00)+uint16(a10)+uint16(a01)+uint16(a11)+2) / 4)
+			a := uint8((uint16(a00) + uint16(a10) + uint16(a01) + uint16(a11) + 2) / 4)
 
 			// RGB: average only pixels with non-zero alpha.
 			var rSum, gSum, bSum uint16

--- a/internal/tile/generator.go
+++ b/internal/tile/generator.go
@@ -151,6 +151,24 @@ func Generate(cfg Config, sources []*cog.Reader, writer TileWriter) (Stats, erro
 
 	var tileCount, emptyCount, uniformCount, grayCount, totalBytes atomic.Int64
 
+	// Pre-encode the fill-color tile once so identical fill tiles across all
+	// zoom levels reuse the same encoded bytes, skipping repeated encoder calls.
+	// For uniform tiles, DiskTileStore.Put ignores encoded bytes (stores compact
+	// TileData), so this cache is only used for WriteTile.
+	// The slice is read-only after creation and safe for concurrent access.
+	var (
+		fillTileShared  *TileData // shared uniform fill tile (immutable, safe to share)
+		fillColorCached []byte    // pre-encoded bytes for the fill tile
+	)
+	if cfg.FillColor != nil {
+		fillTileShared = newTileDataUniform(*cfg.FillColor, cfg.TileSize)
+		var encErr error
+		fillColorCached, encErr = cfg.Encoder.Encode(fillTileShared.AsImage())
+		if encErr != nil {
+			return Stats{}, fmt.Errorf("encoding fill color tile: %w", encErr)
+		}
+	}
+
 	// Process zoom levels from highest to lowest (pyramid approach).
 	for z := cfg.MaxZoom; z >= cfg.MinZoom; z-- {
 		tiles := coord.TilesInBounds(z,
@@ -260,19 +278,20 @@ func Generate(cfg Config, sources []*cog.Reader, writer TileWriter) (Stats, erro
 							tr := store.Get(childZ, 2*x+1, 2*y)
 							bl := store.Get(childZ, 2*x, 2*y+1)
 							br := store.Get(childZ, 2*x+1, 2*y+1)
-							if cfg.FillColor != nil {
-								fillTile := newTileDataUniform(*cfg.FillColor, cfg.TileSize)
+							if fillTileShared != nil {
+								// Reuse the shared fill tile instead of allocating
+								// a new uniform TileData per nil child.
 								if tl == nil {
-									tl = fillTile
+									tl = fillTileShared
 								}
 								if tr == nil {
-									tr = fillTile
+									tr = fillTileShared
 								}
 								if bl == nil {
-									bl = fillTile
+									bl = fillTileShared
 								}
 								if br == nil {
-									br = fillTile
+									br = fillTileShared
 								}
 							}
 							if cfg.IsTerrarium {
@@ -294,15 +313,23 @@ func Generate(cfg Config, sources []*cog.Reader, writer TileWriter) (Stats, erro
 							grayCount.Add(1)
 						}
 
-						// Encode first so we can reuse the encoded bytes for
-						// both the output and the disk tile store.
-						data, err := cfg.Encoder.Encode(td.AsImage())
-						if err != nil {
-							select {
-							case errCh <- fmt.Errorf("encoding tile z%d/%d/%d: %w", z, x, y, err):
-							default:
+						// Encode the tile. Uniform fill-color tiles reuse
+						// pre-encoded bytes to avoid redundant encoder calls;
+						// the PMTiles writer deduplicates identical content anyway,
+						// but skipping re-encoding saves CPU for sparse datasets.
+						var data []byte
+						if fillColorCached != nil && td.IsUniform() && td.Color() == *cfg.FillColor {
+							data = fillColorCached
+						} else {
+							var err error
+							data, err = cfg.Encoder.Encode(td.AsImage())
+							if err != nil {
+								select {
+								case errCh <- fmt.Errorf("encoding tile z%d/%d/%d: %w", z, x, y, err):
+								default:
+								}
+								return
 							}
-							return
 						}
 
 						if err := writer.WriteTile(z, x, y, data); err != nil {

--- a/internal/tile/resample.go
+++ b/internal/tile/resample.go
@@ -4,11 +4,38 @@ import (
 	"image"
 	"math"
 	"strconv"
+	"sync"
 
 	"github.com/pspoerri/geotiff2pmtiles/internal/cog"
 	"github.com/pspoerri/geotiff2pmtiles/internal/coord"
 	"github.com/pspoerri/geotiff2pmtiles/internal/encode"
 )
+
+// lonLatPool recycles paired longitude/latitude arrays used by renderTile and
+// renderTileTerrarium. Each pool entry is a single []float64 of length
+// 2*tileSize — the first half holds longitudes, the second latitudes.
+// Pooling eliminates two make([]float64, tileSize) allocations per tile and
+// the associated zero-initialization cost.
+var lonLatPool sync.Pool
+
+// getLonLat returns a pooled (lons, lats, backing) triple for the given tile
+// size. backing must be passed to putLonLat after use.
+func getLonLat(tileSize int) (lons, lats, backing []float64) {
+	if raw := lonLatPool.Get(); raw != nil {
+		s := raw.([]float64)
+		if len(s) == tileSize*2 {
+			return s[:tileSize], s[tileSize:], s
+		}
+		// Wrong size (shouldn't happen once the pool is warm): discard.
+	}
+	s := make([]float64, tileSize*2)
+	return s[:tileSize], s[tileSize:], s
+}
+
+// putLonLat returns the backing slice to the pool.
+func putLonLat(backing []float64) {
+	lonLatPool.Put(backing)
+}
 
 // sourceInfo caches per-source metadata used during rendering and prefetching.
 type sourceInfo struct {
@@ -128,8 +155,8 @@ func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Proje
 	// Precompute lon per column (linear with pixel X) and lat per row
 	// (non-linear in Mercator, but independent of X). This reduces
 	// expensive PixelToLonLat trig from tileSize² to 2×tileSize calls.
-	lons := make([]float64, tileSize)
-	lats := make([]float64, tileSize)
+	// Use pooled slices to avoid per-tile allocation and zero-init cost.
+	lons, lats, llBacking := getLonLat(tileSize)
 	for px := 0; px < tileSize; px++ {
 		lons[px], _ = coord.PixelToLonLat(z, tx, ty, tileSize, float64(px)+0.5, 0)
 	}
@@ -159,6 +186,8 @@ func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Proje
 			}
 		}
 	}
+
+	putLonLat(llBacking)
 
 	if !hasData {
 		PutRGBA(img)
@@ -194,13 +223,13 @@ func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.
 
 		switch mode {
 		case ResamplingNearest, ResamplingMode:
-			rr, gg, bb, aa, err = nearestSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, cache)
+			rr, gg, bb, aa, err = nearestSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
 		case ResamplingLanczos:
 			rr, gg, bb, aa, err = lanczosSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
 		case ResamplingBicubic:
 			rr, gg, bb, aa, err = bicubicSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
 		default:
-			rr, gg, bb, aa, err = bilinearSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, cache)
+			rr, gg, bb, aa, err = bilinearSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
 		}
 
 		if err != nil {
@@ -219,11 +248,12 @@ func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.
 // the rounded pixel coordinate so it never exceeds the valid range.
 // Without clamping, Floor(fx+0.5) can produce imgW when fx >= imgW-0.5,
 // reading from the zero-padded overhang of the last COG tile.
-func nearestSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
+// tw and th are the source tile dimensions (pre-computed by prepareTileSources).
+func nearestSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
 	px := clamp(int(math.Floor(fx+0.5)), 0, imgW-1)
 	py := clamp(int(math.Floor(fy+0.5)), 0, imgH-1)
 
-	p, err := readPixelCached(src, level, px, py, cache)
+	p, err := readPixelCached(src, level, px, py, tw, th, cache)
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}
@@ -237,7 +267,8 @@ func nearestSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH 
 //
 // Optimized to do at most 2 cache lookups (instead of 4): pixels in the same
 // source tile are extracted directly from the already-fetched image.
-func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
+// tw and th are the source tile dimensions (pre-computed by prepareTileSources).
+func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
 	x0 := int(math.Floor(fx))
 	y0 := int(math.Floor(fy))
 	x1 := x0 + 1
@@ -252,10 +283,6 @@ func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH
 	dy := fy - math.Floor(fy)
 
 	// Pre-compute tile coordinates for all four corners.
-	ifd := src.IFDTileSize(level)
-	tw := ifd[0]
-	th := ifd[1]
-
 	col0, row0 := x0/tw, y0/th
 	col1, row1 := x1/tw, y1/th
 
@@ -1197,11 +1224,8 @@ func pixelFromImage(tile image.Image, x, y int) [4]uint8 {
 }
 
 // readPixelCached reads a single pixel using the tile cache.
-func readPixelCached(src *cog.Reader, level, px, py int, cache *cog.TileCache) ([4]uint8, error) {
-	ifd := src.IFDTileSize(level)
-	tw := ifd[0]
-	th := ifd[1]
-
+// tw and th are the source tile dimensions (pre-computed by prepareTileSources).
+func readPixelCached(src *cog.Reader, level, px, py, tw, th int, cache *cog.TileCache) ([4]uint8, error) {
 	col := px / tw
 	row := py / th
 	localX := px % tw
@@ -1378,8 +1402,8 @@ func renderTileTerrarium(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj co
 	}
 
 	// Precompute lon per column and lat per row to avoid per-pixel trig.
-	lons := make([]float64, tileSize)
-	lats := make([]float64, tileSize)
+	// Use pooled slices to avoid per-tile allocation and zero-init cost.
+	lons, lats, llBacking := getLonLat(tileSize)
 	for px := 0; px < tileSize; px++ {
 		lons[px], _ = coord.PixelToLonLat(z, tx, ty, tileSize, float64(px)+0.5, 0)
 	}
@@ -1399,6 +1423,8 @@ func renderTileTerrarium(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj co
 			// nodata pixels remain transparent (zero RGBA)
 		}
 	}
+
+	putLonLat(llBacking)
 
 	if !hasData {
 		PutRGBA(img)

--- a/internal/tile/resample_test.go
+++ b/internal/tile/resample_test.go
@@ -1,0 +1,304 @@
+package tile
+
+import (
+	"math"
+	"testing"
+)
+
+// --- clamp ---
+
+func TestClamp(t *testing.T) {
+	tests := []struct{ v, lo, hi, want int }{
+		{5, 0, 10, 5},    // in range
+		{-1, 0, 10, 0},   // below lo
+		{11, 0, 10, 10},  // above hi
+		{0, 0, 10, 0},    // at lo
+		{10, 0, 10, 10},  // at hi
+		{0, 0, 0, 0},     // lo == hi
+		{-5, -10, -1, -5}, // negative range, in range
+		{-15, -10, -1, -10}, // below negative lo
+	}
+	for _, tt := range tests {
+		got := clamp(tt.v, tt.lo, tt.hi)
+		if got != tt.want {
+			t.Errorf("clamp(%d, %d, %d) = %d, want %d", tt.v, tt.lo, tt.hi, got, tt.want)
+		}
+	}
+}
+
+// --- clampByte ---
+
+func TestClampByte(t *testing.T) {
+	tests := []struct {
+		v    float64
+		want uint8
+	}{
+		{0, 0},
+		{255, 255},
+		{127.4, 127}, // rounds down
+		{127.5, 128}, // rounds up at 0.5
+		{-1, 0},      // below 0
+		{-100, 0},    // well below 0
+		{256, 255},   // above 255
+		{300, 255},   // well above 255
+		{128.0, 128}, // exact integer
+		{0.4, 0},     // rounds to 0
+		{0.5, 1},     // rounds to 1
+		{254.6, 255}, // rounds to 255
+	}
+	for _, tt := range tests {
+		got := clampByte(tt.v)
+		if got != tt.want {
+			t.Errorf("clampByte(%v) = %d, want %d", tt.v, got, tt.want)
+		}
+	}
+}
+
+// --- lanczos3 kernel ---
+
+func TestLanczos3_AtZero(t *testing.T) {
+	if got := lanczos3(0); got != 1 {
+		t.Errorf("lanczos3(0) = %v, want 1", got)
+	}
+}
+
+func TestLanczos3_ZeroesAtIntegerOffsets(t *testing.T) {
+	// At non-zero integer values within [-3,3], sin(k·π) ≈ 0.
+	for _, x := range []float64{1, 2, -1, -2} {
+		got := lanczos3(x)
+		if math.Abs(got) > 1e-10 {
+			t.Errorf("lanczos3(%v) = %v, want ~0", x, got)
+		}
+	}
+}
+
+func TestLanczos3_ZeroOutsideSupport(t *testing.T) {
+	for _, x := range []float64{3.1, -3.1, 4, -10, 100} {
+		got := lanczos3(x)
+		if got != 0 {
+			t.Errorf("lanczos3(%v) = %v, want 0 (outside support)", x, got)
+		}
+	}
+}
+
+func TestLanczos3_Symmetry(t *testing.T) {
+	for _, x := range []float64{0.5, 1.0, 1.5, 2.0, 2.5, 0.1, 2.9} {
+		pos := lanczos3(x)
+		neg := lanczos3(-x)
+		if math.Abs(pos-neg) > 1e-15 {
+			t.Errorf("lanczos3 not symmetric at x=%v: pos=%v neg=%v", x, pos, neg)
+		}
+	}
+}
+
+func TestLanczos3_PositiveAtCenter(t *testing.T) {
+	// The kernel is positive near the center (|x| < 1).
+	for _, x := range []float64{0.1, 0.5, 0.9} {
+		got := lanczos3(x)
+		if got <= 0 {
+			t.Errorf("lanczos3(%v) = %v, want > 0 near center", x, got)
+		}
+	}
+}
+
+// --- lanczos3LUT vs direct ---
+
+func TestLanczos3LUT_AccuracyVsDirect(t *testing.T) {
+	const maxErr = 0.001
+	for i := 0; i <= 30; i++ {
+		x := float64(i) * 0.1
+		direct := lanczos3(x)
+		lut := lanczos3LUT(x)
+		if math.Abs(direct-lut) > maxErr {
+			t.Errorf("lanczos3LUT(%v): direct=%v lut=%v diff=%v (max %v)",
+				x, direct, lut, math.Abs(direct-lut), maxErr)
+		}
+	}
+}
+
+func TestLanczos3LUT_NegativeInputs(t *testing.T) {
+	const maxErr = 0.001
+	for i := 1; i <= 15; i++ {
+		x := float64(i) * 0.2
+		direct := lanczos3(-x)
+		lut := lanczos3LUT(-x)
+		if math.Abs(direct-lut) > maxErr {
+			t.Errorf("lanczos3LUT(-%v): direct=%v lut=%v", x, direct, lut)
+		}
+	}
+}
+
+func TestLanczos3LUT_OutsideSupport(t *testing.T) {
+	for _, x := range []float64{3.0, 3.1, -3.0, -3.1, 10} {
+		got := lanczos3LUT(x)
+		if got != 0 {
+			t.Errorf("lanczos3LUT(%v) = %v, want 0", x, got)
+		}
+	}
+}
+
+func TestLanczos3LUT_AtZero(t *testing.T) {
+	got := lanczos3LUT(0)
+	if math.Abs(got-1) > 0.001 {
+		t.Errorf("lanczos3LUT(0) = %v, want ~1", got)
+	}
+}
+
+// --- bicubic kernel ---
+
+func TestBicubic_AtZero(t *testing.T) {
+	// bicubic(0) = 1.5*0 - 2.5*0 + 1 = 1.
+	if got := bicubic(0); got != 1 {
+		t.Errorf("bicubic(0) = %v, want 1", got)
+	}
+}
+
+func TestBicubic_ZeroAtBoundary(t *testing.T) {
+	// bicubic(1) = 1.5 - 2.5 + 1 = 0.
+	if got := bicubic(1); math.Abs(got) > 1e-14 {
+		t.Errorf("bicubic(1) = %v, want 0", got)
+	}
+	// bicubic(2) = -0.5*8 + 2.5*4 - 4*2 + 2 = -4+10-8+2 = 0.
+	if got := bicubic(2); math.Abs(got) > 1e-14 {
+		t.Errorf("bicubic(2) = %v, want 0", got)
+	}
+	// bicubic(-1) and bicubic(-2) are the same by symmetry.
+	if got := bicubic(-1); math.Abs(got) > 1e-14 {
+		t.Errorf("bicubic(-1) = %v, want 0", got)
+	}
+}
+
+func TestBicubic_ZeroOutsideSupport(t *testing.T) {
+	for _, x := range []float64{2.1, 3, 10, -2.1, -3, -10} {
+		got := bicubic(x)
+		if got != 0 {
+			t.Errorf("bicubic(%v) = %v, want 0 (outside support)", x, got)
+		}
+	}
+}
+
+func TestBicubic_Symmetry(t *testing.T) {
+	for _, x := range []float64{0.5, 1.0, 1.5, 0.1, 1.9} {
+		pos := bicubic(x)
+		neg := bicubic(-x)
+		if math.Abs(pos-neg) > 1e-15 {
+			t.Errorf("bicubic not symmetric at x=%v: pos=%v neg=%v", x, pos, neg)
+		}
+	}
+}
+
+func TestBicubic_DecreaseInnerRegion(t *testing.T) {
+	// The peak is at x=0 and the function decreases monotonically to x=1 in inner region.
+	prev := bicubic(0.0)
+	for i := 1; i <= 10; i++ {
+		x := float64(i) * 0.1
+		cur := bicubic(x)
+		if cur > prev+1e-12 {
+			t.Errorf("bicubic(%v)=%v > bicubic(%v)=%v; should decrease toward 1",
+				x, cur, x-0.1, prev)
+		}
+		prev = cur
+	}
+}
+
+// --- bicubicLUT vs direct ---
+
+func TestBicubicLUT_AccuracyVsDirect(t *testing.T) {
+	const maxErr = 0.001
+	for i := 0; i <= 20; i++ {
+		x := float64(i) * 0.1
+		direct := bicubic(x)
+		lut := bicubicLUT(x)
+		if math.Abs(direct-lut) > maxErr {
+			t.Errorf("bicubicLUT(%v): direct=%v lut=%v diff=%v (max %v)",
+				x, direct, lut, math.Abs(direct-lut), maxErr)
+		}
+	}
+}
+
+func TestBicubicLUT_NegativeInputs(t *testing.T) {
+	const maxErr = 0.001
+	for i := 1; i <= 10; i++ {
+		x := float64(i) * 0.15
+		direct := bicubic(-x)
+		lut := bicubicLUT(-x)
+		if math.Abs(direct-lut) > maxErr {
+			t.Errorf("bicubicLUT(-%v): direct=%v lut=%v", x, direct, lut)
+		}
+	}
+}
+
+func TestBicubicLUT_OutsideSupport(t *testing.T) {
+	for _, x := range []float64{2.0, 2.5, -2.0, -2.5, 10} {
+		got := bicubicLUT(x)
+		if got != 0 {
+			t.Errorf("bicubicLUT(%v) = %v, want 0", x, got)
+		}
+	}
+}
+
+func TestBicubicLUT_AtZero(t *testing.T) {
+	got := bicubicLUT(0)
+	if math.Abs(got-1) > 0.001 {
+		t.Errorf("bicubicLUT(0) = %v, want ~1", got)
+	}
+}
+
+// --- ParseResampling ---
+
+func TestParseResampling_ValidInputs(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Resampling
+	}{
+		{"lanczos", ResamplingLanczos},
+		{"bicubic", ResamplingBicubic},
+		{"bilinear", ResamplingBilinear},
+		{"nearest", ResamplingNearest},
+		{"mode", ResamplingMode},
+	}
+	for _, tt := range tests {
+		got, err := ParseResampling(tt.input)
+		if err != nil {
+			t.Errorf("ParseResampling(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseResampling(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseResampling_InvalidInputs(t *testing.T) {
+	invalids := []string{
+		"",
+		"Lanczos",
+		"BILINEAR",
+		"cubic",
+		"linear",
+		"average",
+		" bilinear",
+		"bilinear ",
+	}
+	for _, s := range invalids {
+		_, err := ParseResampling(s)
+		if err == nil {
+			t.Errorf("ParseResampling(%q): expected error, got nil", s)
+		}
+	}
+}
+
+func TestParseResampling_AllModesDistinct(t *testing.T) {
+	modes := []string{"lanczos", "bicubic", "bilinear", "nearest", "mode"}
+	seen := make(map[Resampling]string)
+	for _, m := range modes {
+		r, err := ParseResampling(m)
+		if err != nil {
+			t.Fatalf("ParseResampling(%q) failed: %v", m, err)
+		}
+		if prev, ok := seen[r]; ok {
+			t.Errorf("ParseResampling(%q) and ParseResampling(%q) both return %v", m, prev, r)
+		}
+		seen[r] = m
+	}
+}

--- a/internal/tile/resample_test.go
+++ b/internal/tile/resample_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestClamp(t *testing.T) {
 	tests := []struct{ v, lo, hi, want int }{
-		{5, 0, 10, 5},    // in range
-		{-1, 0, 10, 0},   // below lo
-		{11, 0, 10, 10},  // above hi
-		{0, 0, 10, 0},    // at lo
-		{10, 0, 10, 10},  // at hi
-		{0, 0, 0, 0},     // lo == hi
-		{-5, -10, -1, -5}, // negative range, in range
+		{5, 0, 10, 5},       // in range
+		{-1, 0, 10, 0},      // below lo
+		{11, 0, 10, 10},     // above hi
+		{0, 0, 10, 0},       // at lo
+		{10, 0, 10, 10},     // at hi
+		{0, 0, 0, 0},        // lo == hi
+		{-5, -10, -1, -5},   // negative range, in range
 		{-15, -10, -1, -10}, // below negative lo
 	}
 	for _, tt := range tests {

--- a/internal/tile/rgbapool_test.go
+++ b/internal/tile/rgbapool_test.go
@@ -1,0 +1,88 @@
+package tile
+
+import (
+	"image"
+	"testing"
+)
+
+// TestGetRGBA_CorrectDimensions verifies the returned image has the requested bounds.
+func TestGetRGBA_CorrectDimensions(t *testing.T) {
+	for _, sz := range [][2]int{{1, 1}, {4, 8}, {16, 16}, {256, 256}} {
+		w, h := sz[0], sz[1]
+		img := GetRGBA(w, h)
+		if img.Bounds().Dx() != w || img.Bounds().Dy() != h {
+			t.Errorf("GetRGBA(%d,%d) bounds = %v, want %dx%d", w, h, img.Bounds(), w, h)
+		}
+	}
+}
+
+// TestGetRGBA_BoundsOriginAtZero verifies the returned image starts at (0,0).
+func TestGetRGBA_BoundsOriginAtZero(t *testing.T) {
+	img := GetRGBA(16, 16)
+	if img.Bounds().Min != (image.Point{}) {
+		t.Errorf("Bounds().Min = %v, want (0,0)", img.Bounds().Min)
+	}
+}
+
+// TestGetRGBA_ReturnsZeroedImage verifies that GetRGBA always returns a zeroed image,
+// even when reusing a pooled buffer that previously held non-zero data.
+func TestGetRGBA_ReturnsZeroedImage(t *testing.T) {
+	// Get and dirty an image.
+	img := GetRGBA(8, 8)
+	for i := range img.Pix {
+		img.Pix[i] = 0xFF
+	}
+	// Return to pool.
+	PutRGBA(img)
+
+	// Get again — must be zeroed (same size reuses the pool entry).
+	img2 := GetRGBA(8, 8)
+	for i, v := range img2.Pix {
+		if v != 0 {
+			t.Errorf("Pix[%d] = %d after pool reuse, want 0", i, v)
+			break
+		}
+	}
+}
+
+// TestPutRGBA_NilIsSafe verifies PutRGBA does not panic on nil input.
+func TestPutRGBA_NilIsSafe(t *testing.T) {
+	PutRGBA(nil) // must not panic
+}
+
+// TestGetRGBA_DifferentSizesDoNotInterfere verifies that pooled images of one
+// size are not accidentally returned for a different size.
+func TestGetRGBA_DifferentSizesDoNotInterfere(t *testing.T) {
+	small := GetRGBA(4, 4)
+	large := GetRGBA(8, 8)
+
+	PutRGBA(small)
+
+	// Requesting the large size should still return 8×8.
+	reuse := GetRGBA(8, 8)
+	if reuse.Bounds().Dx() != 8 || reuse.Bounds().Dy() != 8 {
+		t.Errorf("GetRGBA(8,8) returned bounds %v after putting 4×4", reuse.Bounds())
+	}
+	PutRGBA(large)
+}
+
+// TestGetRGBA_PoolReuseIdentity verifies that after Put, the next Get of the
+// same size returns the same underlying array (pool actually reuses memory).
+// This is a best-effort check — the GC may have collected the pooled value.
+func TestGetRGBA_PoolReuseIdentity(t *testing.T) {
+	img := GetRGBA(64, 64)
+	PutRGBA(img)
+
+	img2 := GetRGBA(64, 64)
+	// Can't guarantee same pointer across GC cycles, but the returned image
+	// must be correctly sized and zeroed.
+	if img2.Bounds().Dx() != 64 || img2.Bounds().Dy() != 64 {
+		t.Errorf("reused image has wrong bounds: %v", img2.Bounds())
+	}
+	for i, v := range img2.Pix {
+		if v != 0 {
+			t.Errorf("Pix[%d] = %d, want 0", i, v)
+			break
+		}
+	}
+}

--- a/internal/tile/tiledata.go
+++ b/internal/tile/tiledata.go
@@ -1,6 +1,7 @@
 package tile
 
 import (
+	"encoding/binary"
 	"image"
 	"image/color"
 )
@@ -164,14 +165,27 @@ func (t *TileData) At(x, y int) color.Color {
 // Returns the color and true if uniform, or zero-value and false otherwise.
 // The scan is sequential over the Pix slice (cache-friendly) and short-circuits
 // on the first mismatch, so non-uniform tiles bail out almost immediately.
+//
+// Reads 8 bytes (2 pixels) per iteration using binary.LittleEndian.Uint64,
+// reducing comparisons 8× vs the naive per-byte approach and enabling the
+// compiler to emit efficient load instructions.
 func detectUniform(img *image.RGBA) (color.RGBA, bool) {
 	pix := img.Pix
 	if len(pix) < 4 {
 		return color.RGBA{}, false
 	}
 	r, g, b, a := pix[0], pix[1], pix[2], pix[3]
-	for i := 4; i < len(pix); i += 4 {
-		if pix[i] != r || pix[i+1] != g || pix[i+2] != b || pix[i+3] != a {
+	want32 := binary.LittleEndian.Uint32(pix)
+	want64 := uint64(want32) | uint64(want32)<<32
+	n := len(pix)
+	i := 4
+	for ; i+7 < n; i += 8 {
+		if binary.LittleEndian.Uint64(pix[i:]) != want64 {
+			return color.RGBA{}, false
+		}
+	}
+	for ; i+3 < n; i += 4 {
+		if binary.LittleEndian.Uint32(pix[i:]) != want32 {
 			return color.RGBA{}, false
 		}
 	}

--- a/internal/tile/tiledata_test.go
+++ b/internal/tile/tiledata_test.go
@@ -1,0 +1,399 @@
+package tile
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+// --- applyFillColorTransform ---
+
+func TestApplyFillColorTransform_ReplacesTransparentPixels(t *testing.T) {
+	tileSize := 4
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	// Set two pixels to non-transparent values.
+	img.SetRGBA(0, 0, color.RGBA{255, 0, 0, 255})
+	img.SetRGBA(1, 0, color.RGBA{0, 255, 0, 128}) // partial alpha: should NOT be replaced
+	// Remaining pixels are transparent (zero RGBA).
+
+	fill := color.RGBA{100, 100, 100, 255}
+	applyFillColorTransform(img, fill)
+
+	// Fully opaque pixel should be unchanged.
+	if c := img.RGBAAt(0, 0); c != (color.RGBA{255, 0, 0, 255}) {
+		t.Errorf("opaque pixel changed: got %v, want red", c)
+	}
+	// Partially transparent pixel (alpha != 0) should be unchanged.
+	if c := img.RGBAAt(1, 0); c != (color.RGBA{0, 255, 0, 128}) {
+		t.Errorf("partial-alpha pixel changed: got %v", c)
+	}
+	// Fully transparent pixels should be replaced with fill.
+	if c := img.RGBAAt(2, 0); c != fill {
+		t.Errorf("transparent pixel = %v, want fill %v", c, fill)
+	}
+	if c := img.RGBAAt(0, 1); c != fill {
+		t.Errorf("transparent pixel = %v, want fill %v", c, fill)
+	}
+}
+
+func TestApplyFillColorTransform_AllTransparent(t *testing.T) {
+	tileSize := 8
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize)) // all zero (transparent)
+	fill := color.RGBA{50, 60, 70, 255}
+	applyFillColorTransform(img, fill)
+
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			if c := img.RGBAAt(x, y); c != fill {
+				t.Fatalf("pixel (%d,%d) = %v, want fill %v", x, y, c, fill)
+			}
+		}
+	}
+}
+
+func TestApplyFillColorTransform_NoneTransparent(t *testing.T) {
+	tileSize := 4
+	red := color.RGBA{255, 0, 0, 255}
+	img := solidImage(tileSize, red) // all opaque
+	fill := color.RGBA{50, 60, 70, 255}
+	applyFillColorTransform(img, fill)
+
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			if c := img.RGBAAt(x, y); c != red {
+				t.Fatalf("opaque pixel (%d,%d) changed: got %v, want red", x, y, c)
+			}
+		}
+	}
+}
+
+// --- detectGray edge cases ---
+
+func TestDetectGray_AcceptsGrayCheckerboard(t *testing.T) {
+	img := grayCheckerImage(8, 100, 200)
+	g, ok := detectGray(img)
+	if !ok {
+		t.Error("detectGray should accept R=G=B, A=255 image")
+	}
+	if g == nil {
+		t.Fatal("detectGray returned nil image for valid gray input")
+	}
+	if g.Bounds().Dx() != 8 || g.Bounds().Dy() != 8 {
+		t.Errorf("gray image bounds = %v, want 8×8", g.Bounds())
+	}
+}
+
+func TestDetectGray_RejectsAlphaNot255(t *testing.T) {
+	tileSize := 4
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			img.SetRGBA(x, y, color.RGBA{128, 128, 128, 200}) // alpha != 255
+		}
+	}
+	_, ok := detectGray(img)
+	if ok {
+		t.Error("detectGray should reject pixels with alpha != 255")
+	}
+}
+
+func TestDetectGray_RejectsRGBMismatch(t *testing.T) {
+	tileSize := 4
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			img.SetRGBA(x, y, color.RGBA{128, 128, 128, 255})
+		}
+	}
+	// One pixel has R != G.
+	img.SetRGBA(1, 1, color.RGBA{255, 0, 128, 255})
+	_, ok := detectGray(img)
+	if ok {
+		t.Error("detectGray should reject non-gray pixels (R != G)")
+	}
+}
+
+func TestDetectGray_RejectsRGBAImage(t *testing.T) {
+	img := rgbaCheckerImage(8) // has distinct R and B channels
+	_, ok := detectGray(img)
+	if ok {
+		t.Error("detectGray should reject RGBA image with different channel values")
+	}
+}
+
+// --- detectUniform edge cases ---
+
+func TestDetectUniform_TwoIdenticalPixels(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 1))
+	img.SetRGBA(0, 0, color.RGBA{1, 2, 3, 4})
+	img.SetRGBA(1, 0, color.RGBA{1, 2, 3, 4})
+	c, ok := detectUniform(img)
+	if !ok {
+		t.Error("expected uniform for 2 identical pixels")
+	}
+	if c != (color.RGBA{1, 2, 3, 4}) {
+		t.Errorf("color = %v, want {1,2,3,4}", c)
+	}
+}
+
+func TestDetectUniform_OnePixelDiffers(t *testing.T) {
+	img := solidImage(16, color.RGBA{100, 100, 100, 255})
+	img.SetRGBA(15, 15, color.RGBA{100, 100, 101, 255}) // 1 channel differs
+	_, ok := detectUniform(img)
+	if ok {
+		t.Error("expected non-uniform when one pixel differs by 1 channel")
+	}
+}
+
+func TestDetectUniform_AllTransparent(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8)) // all zero
+	c, ok := detectUniform(img)
+	if !ok {
+		t.Error("expected uniform for all-transparent (zero) image")
+	}
+	if c != (color.RGBA{}) {
+		t.Errorf("color = %v, want zero", c)
+	}
+}
+
+// --- TileData serialization round-trips ---
+
+func TestSerializeTileData_RoundTrip_RGBA(t *testing.T) {
+	tileSize := 8
+	img := checkerImage(tileSize, color.RGBA{255, 0, 0, 255}, color.RGBA{0, 0, 255, 255})
+	td := newTileData(img, tileSize)
+	if td.IsUniform() || td.IsGray() {
+		t.Fatal("expected full RGBA tile for checker input")
+	}
+
+	buf, typ := td.SerializeAppend(nil)
+	if typ != tileDataTypeRGBA {
+		t.Errorf("type = %v, want tileDataTypeRGBA", typ)
+	}
+	if len(buf) != tileSize*tileSize*4 {
+		t.Errorf("buf len = %d, want %d", len(buf), tileSize*tileSize*4)
+	}
+
+	td2 := DeserializeTileData(buf, typ, tileSize)
+	if td2 == nil {
+		t.Fatal("DeserializeTileData returned nil for valid RGBA data")
+	}
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			c1 := td.RGBAAt(x, y)
+			c2 := td2.RGBAAt(x, y)
+			if c1 != c2 {
+				t.Fatalf("pixel (%d,%d): original=%v deserialized=%v", x, y, c1, c2)
+			}
+		}
+	}
+}
+
+func TestSerializeTileData_RoundTrip_Gray(t *testing.T) {
+	tileSize := 8
+	img := grayCheckerImage(tileSize, 50, 200)
+	td := newTileData(img, tileSize)
+	if !td.IsGray() {
+		t.Fatal("expected gray tile for gray checker input")
+	}
+
+	buf, typ := td.SerializeAppend(nil)
+	if typ != tileDataTypeGray {
+		t.Errorf("type = %v, want tileDataTypeGray", typ)
+	}
+	if len(buf) != tileSize*tileSize {
+		t.Errorf("buf len = %d, want %d", len(buf), tileSize*tileSize)
+	}
+
+	td2 := DeserializeTileData(buf, typ, tileSize)
+	if td2 == nil {
+		t.Fatal("DeserializeTileData returned nil for valid gray data")
+	}
+	if !td2.IsGray() {
+		t.Error("deserialized tile should be gray")
+	}
+	for y := 0; y < tileSize; y++ {
+		for x := 0; x < tileSize; x++ {
+			c1 := td.RGBAAt(x, y)
+			c2 := td2.RGBAAt(x, y)
+			if c1 != c2 {
+				t.Fatalf("pixel (%d,%d): %v vs %v", x, y, c1, c2)
+			}
+		}
+	}
+}
+
+func TestSerializeTileData_RoundTrip_Uniform(t *testing.T) {
+	tileSize := 8
+	blue := color.RGBA{0, 0, 200, 255}
+	td := newTileDataUniform(blue, tileSize)
+
+	buf, typ := td.SerializeAppend(nil)
+	if typ != tileDataTypeUniform {
+		t.Errorf("type = %v, want tileDataTypeUniform", typ)
+	}
+	if len(buf) != 4 {
+		t.Errorf("uniform buf len = %d, want 4", len(buf))
+	}
+	if buf[0] != blue.R || buf[1] != blue.G || buf[2] != blue.B || buf[3] != blue.A {
+		t.Errorf("serialized bytes = %v, want {0,0,200,255}", buf)
+	}
+
+	td2 := DeserializeTileData(buf, typ, tileSize)
+	if td2 == nil {
+		t.Fatal("DeserializeTileData returned nil for valid uniform data")
+	}
+	if !td2.IsUniform() {
+		t.Error("deserialized uniform tile should be uniform")
+	}
+	if td2.Color() != blue {
+		t.Errorf("color = %v, want %v", td2.Color(), blue)
+	}
+}
+
+func TestSerializeTileData_AppendsToBuf(t *testing.T) {
+	td := newTileDataUniform(color.RGBA{1, 2, 3, 4}, 4)
+	prefix := []byte{0xDE, 0xAD}
+	buf, _ := td.SerializeAppend(prefix)
+	// Prefix bytes should be preserved.
+	if buf[0] != 0xDE || buf[1] != 0xAD {
+		t.Errorf("prefix bytes overwritten: %v", buf[:2])
+	}
+	// Uniform color appended after prefix.
+	if buf[2] != 1 || buf[3] != 2 || buf[4] != 3 || buf[5] != 4 {
+		t.Errorf("color bytes = %v, want [1,2,3,4]", buf[2:])
+	}
+}
+
+func TestDeserializeTileData_TruncatedData(t *testing.T) {
+	tileSize := 8
+	// Uniform needs 4 bytes.
+	if got := DeserializeTileData([]byte{1, 2, 3}, tileDataTypeUniform, tileSize); got != nil {
+		t.Errorf("truncated uniform: expected nil, got non-nil")
+	}
+	// Gray needs tileSize*tileSize bytes.
+	if got := DeserializeTileData([]byte{1, 2, 3}, tileDataTypeGray, tileSize); got != nil {
+		t.Errorf("truncated gray: expected nil, got non-nil")
+	}
+	// RGBA needs tileSize*tileSize*4 bytes.
+	if got := DeserializeTileData([]byte{1, 2, 3}, tileDataTypeRGBA, tileSize); got != nil {
+		t.Errorf("truncated RGBA: expected nil, got non-nil")
+	}
+	// Unknown type should return nil.
+	if got := DeserializeTileData([]byte{1, 2, 3, 4}, tileDataType(99), tileSize); got != nil {
+		t.Errorf("unknown type: expected nil, got non-nil")
+	}
+}
+
+// --- TileData.MemoryBytes ---
+
+func TestTileData_MemoryBytes_Uniform(t *testing.T) {
+	td := newTileDataUniform(color.RGBA{1, 2, 3, 4}, 256)
+	if got := td.MemoryBytes(); got != 4 {
+		t.Errorf("uniform MemoryBytes = %d, want 4", got)
+	}
+}
+
+func TestTileData_MemoryBytes_Gray(t *testing.T) {
+	tileSize := 16
+	img := grayCheckerImage(tileSize, 10, 20)
+	td := newTileData(img, tileSize)
+	if !td.IsGray() {
+		t.Fatal("expected gray tile")
+	}
+	want := int64(tileSize * tileSize)
+	if got := td.MemoryBytes(); got != want {
+		t.Errorf("gray MemoryBytes = %d, want %d", got, want)
+	}
+}
+
+func TestTileData_MemoryBytes_RGBA(t *testing.T) {
+	tileSize := 16
+	img := checkerImage(tileSize, color.RGBA{1, 0, 0, 255}, color.RGBA{0, 0, 1, 255})
+	td := newTileData(img, tileSize)
+	if td.IsUniform() || td.IsGray() {
+		t.Fatal("expected full RGBA tile")
+	}
+	want := int64(tileSize * tileSize * 4)
+	if got := td.MemoryBytes(); got != want {
+		t.Errorf("RGBA MemoryBytes = %d, want %d", got, want)
+	}
+}
+
+// --- TileData.Bounds ---
+
+func TestTileData_Bounds_Uniform(t *testing.T) {
+	tileSize := 32
+	td := newTileDataUniform(color.RGBA{0, 0, 0, 255}, tileSize)
+	b := td.Bounds()
+	if b.Dx() != tileSize || b.Dy() != tileSize {
+		t.Errorf("uniform Bounds = %v, want %dx%d", b, tileSize, tileSize)
+	}
+	if b.Min.X != 0 || b.Min.Y != 0 {
+		t.Errorf("uniform Bounds.Min = %v, want (0,0)", b.Min)
+	}
+}
+
+func TestTileData_Bounds_Gray(t *testing.T) {
+	tileSize := 16
+	img := grayCheckerImage(tileSize, 50, 100)
+	td := newTileData(img, tileSize)
+	if !td.IsGray() {
+		t.Fatal("expected gray tile")
+	}
+	b := td.Bounds()
+	if b.Dx() != tileSize || b.Dy() != tileSize {
+		t.Errorf("gray Bounds = %v, want %dx%d", b, tileSize, tileSize)
+	}
+}
+
+// --- TileData.IsGray and IsUniform classification ---
+
+func TestTileData_IsGray_TrueForGrayInput(t *testing.T) {
+	img := grayCheckerImage(8, 100, 200)
+	td := newTileData(img, 8)
+	if !td.IsGray() {
+		t.Error("expected IsGray() = true for gray checker image")
+	}
+	if td.IsUniform() {
+		t.Error("expected IsUniform() = false for non-uniform gray tile")
+	}
+}
+
+func TestTileData_IsGray_FalseForRGBA(t *testing.T) {
+	img := checkerImage(8, color.RGBA{255, 0, 0, 255}, color.RGBA{0, 0, 255, 255})
+	td := newTileData(img, 8)
+	if td.IsGray() {
+		t.Error("expected IsGray() = false for RGBA checker image")
+	}
+	if td.IsUniform() {
+		t.Error("expected IsUniform() = false for RGBA checker")
+	}
+}
+
+func TestTileData_isUniformGray(t *testing.T) {
+	// Uniform gray: R=G=B, A=255 → isUniformGray = true.
+	td := newTileDataUniform(color.RGBA{100, 100, 100, 255}, 8)
+	if !td.isUniformGray() {
+		t.Error("expected isUniformGray() = true for uniform gray tile")
+	}
+
+	// Uniform color (not gray): isUniformGray = false.
+	tdColor := newTileDataUniform(color.RGBA{100, 0, 0, 255}, 8)
+	if tdColor.isUniformGray() {
+		t.Error("expected isUniformGray() = false for non-gray uniform tile")
+	}
+
+	// Uniform with alpha != 255: isUniformGray = false.
+	tdTransparent := newTileDataUniform(color.RGBA{100, 100, 100, 0}, 8)
+	if tdTransparent.isUniformGray() {
+		t.Error("expected isUniformGray() = false for transparent uniform tile")
+	}
+
+	// Non-uniform tile: isUniformGray = false.
+	img := grayCheckerImage(8, 50, 150)
+	tdGray := newTileData(img, 8)
+	if tdGray.isUniformGray() {
+		t.Error("expected isUniformGray() = false for non-uniform gray tile")
+	}
+}


### PR DESCRIPTION
## Summary

- **Performance optimizations** (`c816385`): Five targeted improvements to tile generation throughput:
  - Eliminate per-pixel `IFDTileSize()` call in bilinear/nearest/readPixel by passing pre-computed `tw`/`th` from `tileSource`
  - Pool `lons`/`lats` float64 slices in `renderTile`/`renderTileTerrarium` via `sync.Pool` to avoid two `make()` + zero-init allocations per tile
  - Rewrite `downsampleQuadrantBilinear`/`Nearest`/`Mode` with direct `Pix` slice access, removing provably-unnecessary bounds checks
  - Use `uint64` word comparison in `detectUniform` for 8-byte-at-a-time scan instead of per-byte comparison
  - Pre-encode fill-color tile once and cache bytes; reuse shared `TileData` for nil children in downsample loop
  - Measured gains: `DetectUniform` 3.25×, Downsample Nearest 2.9×, Downsample Bilinear 3.47× vs baseline

- **Benchmarks** (`8466ae1`): Add performance benchmarks for every hot path across all packages — `cog`, `coord`, `encode`, `pmtiles`, and `tile`. Covers detection, tile construction, serialization, resampling (all 5 modes × RGBA/gray/uniform/Terrarium), encoding round-trips, LUT vs direct kernel comparisons, RGBA pool throughput, and `DiskTileStore` Put/Get with and without disk spilling.

- **Unit tests** (`050f2bb`): Add 65 correctness tests for previously uncovered logic in the `tile` package:
  - `resample_test.go` — `clamp`, `clampByte`, `lanczos3`/LUT, `bicubic`/LUT, `ParseResampling` (all modes + invalid inputs)
  - `tiledata_test.go` — `applyFillColorTransform`, `detectGray` edge cases, serialization round-trips for all three storage types, `MemoryBytes`, `Bounds`, type classification
  - `diskstore_test.go` — Put/Get (uniform + encoded), disk spill roundtrip, `Drain` idempotency, `Close` removes temp file, concurrent Put
  - `rgbapool_test.go` — dimensions, zeroing on pool reuse, nil safety, independent buckets per size

## Test plan

- [x] `make test` passes
- [x] `make test-race` passes (concurrent `DiskTileStore` and pool tests verified clean)
- [x] `make bench` runs without hanging