### PR TITLE
Fix deadlock in DiskTileStore backpressure when mapOverhead exceeds memory limit

### DIFF
--- a/internal/tile/diskstore.go
+++ b/internal/tile/diskstore.go
@@ -205,9 +205,14 @@ func (s *DiskTileStore) Put(z, x, y int, td *TileData, encoded []byte) {
 	// This must happen AFTER the ioCh send so the ioLoop always has work
 	// to process — otherwise a single blocked worker with no pending I/O
 	// would deadlock.
+	//
+	// Only gate on memBytes (evictable encoded tile data), not mapOverhead.
+	// mapOverhead only grows (one entry per tile ever written) and can never
+	// be reduced, so including it in the condition would cause a permanent
+	// deadlock once enough tiles have been spilled.
 	if s.memCond != nil {
 		s.spillMu.Lock()
-		for s.totalMemory() > s.memoryLimit {
+		for s.memBytes.Load() > s.memoryLimit {
 			s.memCond.Wait()
 		}
 		s.spillMu.Unlock()


### PR DESCRIPTION
The Put() backpressure loop used totalMemory() (memBytes + mapOverhead) as the wait condition. mapOverhead grows by 64 bytes for every tile spilled to disk and is never decremented. With a small memory limit, once enough tiles were spilled, mapOverhead alone exceeded the limit — Put() re-entered Wait() but the I/O goroutine had nothing left to process, so memCond was never broadcast again, causing a permanent deadlock.

Fix: gate the backpressure wait on memBytes only (the evictable encoded tile data). mapOverhead is permanent accounting that cannot be reduced and must not participate in the condition.