### PR TITLE
Change default --fill-color to transparent (0,0,0,0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--resampling`  | `bicubic`     | Interpolation method: `lanczos`, `bicubic`, `bilinear`, `nearest`, `mode` |
 | `--mem-limit`   | auto          | Tile store memory limit in MB before disk spilling (0 = auto ~90% of RAM) |
 | `--no-spill`    | `false`       | Disable disk spilling (keep all tiles in memory)   |
-| `--fill-color`  |               | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` |
+| `--fill-color`  | `0,0,0,0`     | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` (default: transparent) |
 | `--attribution` |               | Attribution string for data sources (stored in metadata) |
 | `--type`        | `baselayer`   | Layer type: `baselayer`, `overlay`                 |
 | `--bands`       | `1,2,3`       | 1-indexed band numbers for R,G,B output (e.g. `4,1,2` for NIR-R-G false color) |
@@ -148,7 +148,7 @@ Categorical data (e.g. land cover classification) with mode resampling:
   landcover/ classification.pmtiles
 ```
 
-Fill transparent/nodata areas with a solid color:
+Fill transparent/nodata areas with a solid color (e.g. black):
 
 ```bash
 ./geotiff2pmtiles --fill-color "0,0,0,255" --format png \
@@ -215,7 +215,7 @@ pmtransform [flags] <input.pmtiles> <output.pmtiles>
 | `--tile-size`   | keep source   | Output tile size in pixels (inferred from first decoded tile) |
 | `--resampling`  | `bicubic`     | Interpolation method: `lanczos`, `bicubic`, `bilinear`, `nearest`, `mode` |
 | `--rebuild`     | `false`       | Force full pyramid rebuild (for resampling changes) |
-| `--fill-color`  |               | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` |
+| `--fill-color`  | `0,0,0,0`     | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` (default: transparent) |
 | `--concurrency` | `NumCPU`      | Number of parallel workers                         |
 | `--mem-limit`   | auto          | Tile store memory limit in MB (0 = auto ~90% of RAM) |
 | `--no-spill`    | `false`       | Disable disk spilling                              |
@@ -247,7 +247,7 @@ Rebuild the entire pyramid with Lanczos resampling:
 Substitute transparent/nodata with black and fill missing tile positions:
 
 ```bash
-./pmtransform --fill-color "0,0,0,0" input.pmtiles output.pmtiles
+./pmtransform --fill-color "0,0,0,255" input.pmtiles output.pmtiles
 ```
 
 Remove higher zoom levels (keep only z10-z14):

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -66,7 +66,7 @@ func main() {
 	flag.StringVar(&memProfile, "memprofile", "", "Write memory profile to file")
 	flag.IntVar(&memLimitMB, "mem-limit", 0, "Tile store memory limit in MB before disk spilling (0 = auto ~90% of RAM)")
 	flag.BoolVar(&noSpill, "no-spill", false, "Disable disk spilling (keep all tiles in memory)")
-	flag.StringVar(&fillColor, "fill-color", "", "Substitute transparent/nodata with RGBA (color transform); also fill missing tile positions, e.g. \"0,0,0,255\" or \"#000000ff\"")
+	flag.StringVar(&fillColor, "fill-color", "0,0,0,0", "Substitute transparent/nodata with RGBA (color transform); also fill missing tile positions, e.g. \"0,0,0,255\" or \"#000000ff\" (default: transparent)")
 	flag.StringVar(&attribution, "attribution", "", "Attribution string for data sources (stored in metadata)")
 	flag.StringVar(&layerType, "type", "baselayer", "Layer type: baselayer, overlay")
 	flag.StringVar(&bandsStr, "bands", "1,2,3", "1-indexed band numbers for R,G,B output (e.g. \"4,1,2\" for NIR-R-G)")

--- a/cmd/pmtransform/main.go
+++ b/cmd/pmtransform/main.go
@@ -60,7 +60,7 @@ func main() {
 	flag.StringVar(&memProfile, "memprofile", "", "Write memory profile to file")
 	flag.IntVar(&memLimitMB, "mem-limit", 0, "Tile store memory limit in MB before disk spilling (0 = auto ~90% of RAM)")
 	flag.BoolVar(&noSpill, "no-spill", false, "Disable disk spilling (keep all tiles in memory)")
-	flag.StringVar(&fillColor, "fill-color", "", "Substitute transparent/nodata with RGBA (color transform); also fill missing tile positions, e.g. \"0,0,0,255\" or \"#000000ff\"")
+	flag.StringVar(&fillColor, "fill-color", "0,0,0,0", "Substitute transparent/nodata with RGBA (color transform); also fill missing tile positions, e.g. \"0,0,0,255\" or \"#000000ff\" (default: transparent)")
 	flag.BoolVar(&rebuild, "rebuild", false, "Force full pyramid rebuild (required for resampling changes)")
 	flag.StringVar(&attribution, "attribution", "", "Attribution string for data sources (default: keep source)")
 	flag.StringVar(&layerType, "type", "", "Layer type: baselayer, overlay (default: keep source)")


### PR DESCRIPTION
Missing tile positions and transparent/nodata pixels are now filled with rgba(0,0,0,0) by default instead of being absent from the archive, so areas outside data coverage render as transparent in map viewers rather than as the viewer's default background color.