### PR TITLE
Switch ESA WorldCover test datasets from N00E009 to N46E008

### DIFF
--- a/integration/satellite_esaworldcover_gamma0_test.go
+++ b/integration/satellite_esaworldcover_gamma0_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pspoerri/geotiff2pmtiles/internal/pmtiles"
 )
 
-const esaGamma0File = "ESA_WorldCover_10m_2021_v200_N00E009_S1VVVHratio.tif"
+const esaGamma0File = "ESA_WorldCover_10m_2021_v200_N46E008_S1VVVHratio.tif"
 
 func openESAGamma0(t *testing.T) string {
 	t.Helper()
@@ -87,10 +87,10 @@ func TestESAWorldCoverGamma0Pipeline(t *testing.T) {
 		MinZoom:       7,
 		MaxZoom:       9,
 		TileType:      pmtiles.TileTypePNG,
-		MinLon:        9,
-		MaxLon:        10,
-		MinLat:        0,
-		MaxLat:        1,
+		MinLon:        8,
+		MaxLon:        9,
+		MinLat:        46,
+		MaxLat:        47,
 		BoundsTol:     2,
 		MinTotalTiles: 5,
 	})

--- a/integration/satellite_esaworldcover_ndvi_test.go
+++ b/integration/satellite_esaworldcover_ndvi_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pspoerri/geotiff2pmtiles/internal/pmtiles"
 )
 
-const esaNDVIFile = "ESA_WorldCover_10m_2021_v200_N00E009_NDVI.tif"
+const esaNDVIFile = "ESA_WorldCover_10m_2021_v200_N46E008_NDVI.tif"
 
 func openESANDVI(t *testing.T) string {
 	t.Helper()
@@ -73,10 +73,10 @@ func TestESAWorldCoverNDVIPipeline(t *testing.T) {
 		MinZoom:       7,
 		MaxZoom:       9,
 		TileType:      pmtiles.TileTypePNG,
-		MinLon:        9,
-		MaxLon:        10,
-		MinLat:        0,
-		MaxLat:        1,
+		MinLon:        8,
+		MaxLon:        9,
+		MinLat:        46,
+		MaxLat:        47,
 		BoundsTol:     2,
 		MinTotalTiles: 5,
 	})

--- a/integration/satellite_esaworldcover_swir_test.go
+++ b/integration/satellite_esaworldcover_swir_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pspoerri/geotiff2pmtiles/internal/pmtiles"
 )
 
-const esaSWIRFile = "ESA_WorldCover_10m_2021_v200_N00E009_SWIR.tif"
+const esaSWIRFile = "ESA_WorldCover_10m_2021_v200_N46E008_SWIR.tif"
 
 func openESASWIR(t *testing.T) string {
 	t.Helper()
@@ -77,10 +77,10 @@ func TestESAWorldCoverSWIRPipeline(t *testing.T) {
 		MinZoom:       7,
 		MaxZoom:       9,
 		TileType:      pmtiles.TileTypePNG,
-		MinLon:        9,
-		MaxLon:        10,
-		MinLat:        0,
-		MaxLat:        1,
+		MinLon:        8,
+		MaxLon:        9,
+		MinLat:        46,
+		MaxLat:        47,
 		BoundsTol:     2,
 		MinTotalTiles: 5,
 	})

--- a/integration/satellite_esaworldcover_test.go
+++ b/integration/satellite_esaworldcover_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pspoerri/geotiff2pmtiles/internal/pmtiles"
 )
 
-const esaWorldCoverFile = "ESA_WorldCover_10m_2021_v200_N00E009_S2RGBNIR.tif"
+const esaWorldCoverFile = "ESA_WorldCover_10m_2021_v200_N46E008_S2RGBNIR.tif"
 
 func openESAWorldCover(t *testing.T) string {
 	t.Helper()
@@ -98,10 +98,10 @@ func TestESAWorldCoverPipeline(t *testing.T) {
 		MinZoom:       7,
 		MaxZoom:       9,
 		TileType:      pmtiles.TileTypePNG,
-		MinLon:        9,
-		MaxLon:        10,
-		MinLat:        0,
-		MaxLat:        1,
+		MinLon:        8,
+		MaxLon:        9,
+		MinLat:        46,
+		MaxLat:        47,
 		BoundsTol:     2,
 		MinTotalTiles: 5,
 	})

--- a/integration/testdata/download.sh
+++ b/integration/testdata/download.sh
@@ -24,23 +24,23 @@ NE_FILE="HYP_HR_SR_OB_DR.tif"
 
 # --- ESA WorldCover S2 RGBNIR composite (16-bit 4-band, EPSG:4326, ~455 MB) ---
 ESA_RGBNIR_DIR="$SCRIPT_DIR/esaworldcover"
-ESA_RGBNIR_URL="https://esa-worldcover-s2.s3.eu-central-1.amazonaws.com/rgbnir/2021/N00/ESA_WorldCover_10m_2021_v200_N00E009_S2RGBNIR.tif"
-ESA_RGBNIR_FILE="ESA_WorldCover_10m_2021_v200_N00E009_S2RGBNIR.tif"
+ESA_RGBNIR_URL="https://esa-worldcover-s2.s3.eu-central-1.amazonaws.com/rgbnir/2021/N46/ESA_WorldCover_10m_2021_v200_N46E008_S2RGBNIR.tif"
+ESA_RGBNIR_FILE="ESA_WorldCover_10m_2021_v200_N46E008_S2RGBNIR.tif"
 
 # --- ESA WorldCover S2 NDVI (single-band, EPSG:4326, ~168 MB) ---
 ESA_NDVI_DIR="$SCRIPT_DIR/esaworldcover-ndvi"
-ESA_NDVI_URL="https://esa-worldcover-s2.s3.eu-central-1.amazonaws.com/ndvi/2021/N00/ESA_WorldCover_10m_2021_v200_N00E009_NDVI.tif"
-ESA_NDVI_FILE="ESA_WorldCover_10m_2021_v200_N00E009_NDVI.tif"
+ESA_NDVI_URL="https://esa-worldcover-s2.s3.eu-central-1.amazonaws.com/ndvi/2021/N46/ESA_WorldCover_10m_2021_v200_N46E008_NDVI.tif"
+ESA_NDVI_FILE="ESA_WorldCover_10m_2021_v200_N46E008_NDVI.tif"
 
 # --- ESA WorldCover S2 SWIR (single-band, EPSG:4326, ~20 MB) ---
 ESA_SWIR_DIR="$SCRIPT_DIR/esaworldcover-swir"
-ESA_SWIR_URL="https://esa-worldcover-s2.s3.eu-central-1.amazonaws.com/swir/2021/N00/ESA_WorldCover_10m_2021_v200_N00E009_SWIR.tif"
-ESA_SWIR_FILE="ESA_WorldCover_10m_2021_v200_N00E009_SWIR.tif"
+ESA_SWIR_URL="https://esa-worldcover-s2.s3.eu-central-1.amazonaws.com/swir/2021/N46/ESA_WorldCover_10m_2021_v200_N46E008_SWIR.tif"
+ESA_SWIR_FILE="ESA_WorldCover_10m_2021_v200_N46E008_SWIR.tif"
 
 # --- ESA WorldCover S1 VV/VH ratio / gamma0 (SAR, EPSG:4326, ~346 MB) ---
 ESA_GAMMA0_DIR="$SCRIPT_DIR/esaworldcover-gamma0"
-ESA_GAMMA0_URL="https://esa-worldcover-s1.s3.eu-central-1.amazonaws.com/vvvhratio/2021/N00/ESA_WorldCover_10m_2021_v200_N00E009_S1VVVHratio.tif"
-ESA_GAMMA0_FILE="ESA_WorldCover_10m_2021_v200_N00E009_S1VVVHratio.tif"
+ESA_GAMMA0_URL="https://esa-worldcover-s1.s3.eu-central-1.amazonaws.com/vvvhratio/2021/N46/ESA_WorldCover_10m_2021_v200_N46E008_S1VVVHratio.tif"
+ESA_GAMMA0_FILE="ESA_WorldCover_10m_2021_v200_N46E008_S1VVVHratio.tif"
 
 # --- swisstopo SWISSIMAGE DOP10 (8-bit RGB, EPSG:2056 LV95, 10cm, ~36 tiles) ---
 SWISSIMAGE_DIR="$SCRIPT_DIR/swissimage"
@@ -82,10 +82,10 @@ if [ ! -f "$NE_DIR/$NE_FILE" ]; then
 fi
 
 # Download ESA WorldCover datasets
-download_file "$ESA_RGBNIR_URL" "$ESA_RGBNIR_DIR/$ESA_RGBNIR_FILE" "ESA WorldCover S2 RGBNIR (N00 E009)"
-download_file "$ESA_NDVI_URL" "$ESA_NDVI_DIR/$ESA_NDVI_FILE" "ESA WorldCover S2 NDVI (N00 E009)"
-download_file "$ESA_SWIR_URL" "$ESA_SWIR_DIR/$ESA_SWIR_FILE" "ESA WorldCover S2 SWIR (N00 E009)"
-download_file "$ESA_GAMMA0_URL" "$ESA_GAMMA0_DIR/$ESA_GAMMA0_FILE" "ESA WorldCover S1 Gamma0 VV/VH ratio (N00 E009)"
+download_file "$ESA_RGBNIR_URL" "$ESA_RGBNIR_DIR/$ESA_RGBNIR_FILE" "ESA WorldCover S2 RGBNIR (N46 E008)"
+download_file "$ESA_NDVI_URL" "$ESA_NDVI_DIR/$ESA_NDVI_FILE" "ESA WorldCover S2 NDVI (N46 E008)"
+download_file "$ESA_SWIR_URL" "$ESA_SWIR_DIR/$ESA_SWIR_FILE" "ESA WorldCover S2 SWIR (N46 E008)"
+download_file "$ESA_GAMMA0_URL" "$ESA_GAMMA0_DIR/$ESA_GAMMA0_FILE" "ESA WorldCover S1 Gamma0 VV/VH ratio (N46 E008)"
 
 # Download SWISSIMAGE DOP10 tiles (from URL list)
 if [ -f "$SWISSIMAGE_CSV" ]; then

--- a/integration/testdata/esaworldcover-gamma0/README.md
+++ b/integration/testdata/esaworldcover-gamma0/README.md
@@ -4,11 +4,11 @@ Sentinel-1 SAR median gamma0 backscatter composite at 10m resolution.
 
 ## File
 
-`ESA_WorldCover_10m_2021_v200_N00E009_S1VVVHratio.tif` — 16-bit 3-band COG, EPSG:4326, ~346 MB
+`ESA_WorldCover_10m_2021_v200_N46E008_S1VVVHratio.tif` — 16-bit 3-band COG, EPSG:4326, ~346 MB
 
 3 bands: VV, VH, VH/VV ratio. Data is dB-scaled (SCALE=0.001, OFFSET=-45):
 physical dB = pixel_value * 0.001 - 45. 12000x12000 pixels.
-Tile covers N00 E009 (Gulf of Guinea / Cameroon coast).
+Tile covers N46 E008 (Swiss Alps, Bernese Oberland region).
 
 ## Source
 

--- a/integration/testdata/esaworldcover-ndvi/README.md
+++ b/integration/testdata/esaworldcover-ndvi/README.md
@@ -4,10 +4,10 @@ Sentinel-2 NDVI temporal percentile composite at 10m resolution.
 
 ## File
 
-`ESA_WorldCover_10m_2021_v200_N00E009_NDVI.tif` — 8-bit 3-band COG, EPSG:4326, ~168 MB
+`ESA_WorldCover_10m_2021_v200_N46E008_NDVI.tif` — 8-bit 3-band COG, EPSG:4326, ~168 MB
 
 3 bands: NDVI-p90 (upper range), NDVI-p50 (median), NDVI-p10 (lower range).
-12000x12000 pixels. Tile covers N00 E009 (Gulf of Guinea / Cameroon coast).
+12000x12000 pixels. Tile covers N46 E008 (Swiss Alps, Bernese Oberland region).
 
 ## Source
 

--- a/integration/testdata/esaworldcover-swir/README.md
+++ b/integration/testdata/esaworldcover-swir/README.md
@@ -4,10 +4,10 @@ Sentinel-2 shortwave infrared median composite at 20m resolution.
 
 ## File
 
-`ESA_WorldCover_10m_2021_v200_N00E009_SWIR.tif` — 8-bit 2-band COG, EPSG:4326, ~20 MB
+`ESA_WorldCover_10m_2021_v200_N46E008_SWIR.tif` — 8-bit 2-band COG, EPSG:4326, ~20 MB
 
 2 bands: B11-p50, B12-p50 (median shortwave infrared reflectance).
-6000x6000 pixels (20m resolution). Tile covers N00 E009 (Gulf of Guinea / Cameroon coast).
+6000x6000 pixels (20m resolution). Tile covers N46 E008 (Swiss Alps, Bernese Oberland region).
 
 ## Source
 

--- a/integration/testdata/esaworldcover/README.md
+++ b/integration/testdata/esaworldcover/README.md
@@ -4,10 +4,10 @@ Sentinel-2 median Red-Green-Blue-NIR composite at 10m resolution.
 
 ## File
 
-`ESA_WorldCover_10m_2021_v200_N00E009_S2RGBNIR.tif` — 16-bit 4-band COG, EPSG:4326, ~455 MB
+`ESA_WorldCover_10m_2021_v200_N46E008_S2RGBNIR.tif` — 16-bit 4-band COG, EPSG:4326, ~455 MB
 
 4 bands: B04 (Red), B03 (Green), B02 (Blue), B08 (NIR). Values scaled by 10000
-(SCALE=0.0001). Tile covers N00 E009 (Gulf of Guinea / Cameroon coast).
+(SCALE=0.0001). Tile covers N46 E008 (Swiss Alps, Bernese Oberland region).
 
 ## Source
 


### PR DESCRIPTION
Updates all four ESA WorldCover integration test datasets (RGBNIR, NDVI, SWIR, Gamma0) to use the N46 E008 tile (Swiss Alps, Bernese Oberland), matching the geographic area of the Copernicus DEM GLO-30 dataset.