### PR TITLE
Add --resampling-gamma flag for gamma-corrected resampling output

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@ internal/
   tile/
     generator.go                    Parallel tile generation pipeline (GeoTIFF sources)
     transform.go                    PMTiles transform pipeline (passthrough/re-encode/rebuild)
-    resample.go                     Lanczos/bicubic/bilinear/nearest/mode interpolation + reprojection (LUT-accelerated)
+    resample.go                     Lanczos/bicubic/bilinear/nearest/mode interpolation + reprojection (LUT-accelerated, optional gamma encode)
     downsample.go                   Pyramid downsampling for lower zoom levels
     diskstore.go                    Disk-backed tile store with memory backpressure
     rgbapool.go                     sync.Pool for *image.RGBA reuse (keyed by dimensions)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,21 @@
 # Design Decisions
 
+## Resampling gamma correction
+
+When converting from dB-space (e.g. SAR backscatter) to RGB for display, the resulting
+pixel values can appear too dark because dB values concentrate in the lower end of the
+byte range. The `--resampling-gamma` flag applies a power-law gamma encode to the
+interpolated output: `output = (interpolated/255)^(1/gamma) * 255`. This brightens
+midtones and improves visual contrast without altering the interpolation kernel itself.
+
+Only the encode step is applied — there is no decode of source pixels. This keeps the
+accumulation arithmetic unchanged and avoids an extra LUT lookup per pixel per channel
+in the inner loop. The encode table uses 4096 entries for sub-byte precision.
+
+Alpha is never gamma-corrected (it is linear by definition). Nearest/mode resampling
+and Terrarium (elevation) paths skip gamma entirely. The default gamma of 1.0 produces
+bit-identical output to the previous behavior.
+
 ## Startup settings display
 
 Always print the effective configuration (format, tile size, zoom range, resampling,

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ example-esaworldcover: build test-integration-download
 		--format $(FORMAT) \
 		--quality $(QUALITY) \
 		--tile-size $(TILE_SIZE) \
+		--resampling-gamma 1.8 \
 		--concurrency $(CONCURRENT) \
 		$(ESAWORLDCOVER_DIR)/ $(BUILD_DIR)/example-esaworldcover-$(FORMAT).pmtiles
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--tile-size`   | `256`         | Output tile size in pixels                         |
 | `--concurrency` | `NumCPU`      | Number of parallel workers                         |
 | `--resampling`  | `bicubic`     | Interpolation method: `lanczos`, `bicubic`, `bilinear`, `nearest`, `mode` |
+| `--resampling-gamma` | `1.0`    | Gamma correction for resampling output encoding (1.0 = disabled, typical 1.5–2.2 for dB-space to RGB) |
 | `--mem-limit`   | auto          | Tile store memory limit in MB before disk spilling (0 = auto ~90% of RAM) |
 | `--no-spill`    | `false`       | Disable disk spilling (keep all tiles in memory)   |
 | `--fill-color`  | `0,0,0,0`     | Substitute transparent/nodata with RGBA color (color transform); also fill missing tile positions. E.g. `"0,0,0,255"` or `"#000000ff"` (default: transparent) |

--- a/changes/2026-02-28-resampling-gamma.md
+++ b/changes/2026-02-28-resampling-gamma.md
@@ -1,0 +1,27 @@
+# Resampling Gamma Correction
+
+Add `--resampling-gamma` flag to geotiff2pmtiles and pmtransform for gamma-corrected
+output encoding after resampling interpolation. Useful for brightening midtones when
+converting from dB-space (e.g. SAR backscatter) to RGB for display.
+
+## What changed
+
+- New `--resampling-gamma` CLI flag in both geotiff2pmtiles and pmtransform
+  (default 1.0 = disabled, typical values 1.5–2.2)
+- `gammaLUTs` struct with precomputed 4096-entry encode table in `resample.go`
+- All interpolating resampling methods (bilinear, Lanczos-3, bicubic) accept and
+  use the gamma LUTs for output encoding; accumulation stays in source value space
+- `Config.ResamplingGamma` and `TransformConfig.ResamplingGamma` fields wired
+  through `Generate()` and `Transform()` pipelines
+- Terrarium (elevation) and nearest/mode resampling paths are unaffected
+- Alpha channel is never gamma-corrected (always linear)
+
+## Files modified
+
+- `internal/tile/resample.go` — gammaLUTs struct, buildGammaLUTs(), encode(), all
+  interpolating functions and accumulator variants accept `*gammaLUTs`
+- `internal/tile/generator.go` — Config.ResamplingGamma field, LUT construction
+- `internal/tile/transform.go` — TransformConfig.ResamplingGamma field
+- `cmd/geotiff2pmtiles/main.go` — `--resampling-gamma` flag, config output
+- `cmd/pmtransform/main.go` — `--resampling-gamma` flag, config output
+- `internal/tile/resample_test.go` — gamma LUT unit tests

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -30,27 +30,28 @@ var (
 
 func main() {
 	var (
-		format       string
-		quality      int
-		minZoom      int
-		maxZoom      int
-		showVersion  bool
-		tileSize     int
-		concurrency  int
-		verbose      bool
-		resampling   string
-		cpuProfile   string
-		memProfile   string
-		memLimitMB   int
-		noSpill      bool
-		fillColor    string
-		attribution  string
-		layerType    string
-		bandsStr     string
-		alphaBandStr string
-		rescaleStr   string
-		rescaleRange string
-		nodataStr    string
+		format          string
+		quality         int
+		minZoom         int
+		maxZoom         int
+		showVersion     bool
+		tileSize        int
+		concurrency     int
+		verbose         bool
+		resampling      string
+		cpuProfile      string
+		memProfile      string
+		memLimitMB      int
+		noSpill         bool
+		fillColor       string
+		attribution     string
+		layerType       string
+		bandsStr        string
+		alphaBandStr    string
+		rescaleStr      string
+		rescaleRange    string
+		nodataStr       string
+		resamplingGamma float64
 	)
 
 	flag.StringVar(&format, "format", "jpeg", "Tile encoding: jpeg, png, webp, terrarium")
@@ -60,6 +61,7 @@ func main() {
 	flag.IntVar(&tileSize, "tile-size", 256, "Output tile size in pixels")
 	flag.IntVar(&concurrency, "concurrency", runtime.NumCPU(), "Number of parallel workers")
 	flag.StringVar(&resampling, "resampling", "bicubic", "Interpolation method: lanczos, bicubic, bilinear, nearest, mode")
+	flag.Float64Var(&resamplingGamma, "resampling-gamma", 1.0, "Gamma correction for resampling output encoding (1.0 = disabled, typical 1.5-2.2 for dB-space to RGB)")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose progress output")
 	flag.BoolVar(&showVersion, "version", false, "Print version and exit")
 	flag.StringVar(&cpuProfile, "cpuprofile", "", "Write CPU profile to file")
@@ -291,7 +293,11 @@ func main() {
 	}
 	fmt.Printf("  %-14s %dpx\n", "Tile size:", tileSize)
 	fmt.Printf("  %-14s %d – %d (auto-max: %d)\n", "Zoom:", minZoom, maxZoom, autoMax)
-	fmt.Printf("  %-14s %s\n", "Resampling:", resampling)
+	if resamplingGamma != 1.0 {
+		fmt.Printf("  %-14s %s (gamma %.2g)\n", "Resampling:", resampling, resamplingGamma)
+	} else {
+		fmt.Printf("  %-14s %s\n", "Resampling:", resampling)
+	}
 	fmt.Printf("  %-14s %d\n", "Concurrency:", concurrency)
 	if fc != nil {
 		fmt.Printf("  %-14s rgba(%d,%d,%d,%d)\n", "Fill color:", fc.R, fc.G, fc.B, fc.A)
@@ -334,6 +340,7 @@ func main() {
 		Encoder:          enc,
 		Bounds:           mergedBounds,
 		Resampling:       resamplingMode,
+		ResamplingGamma:  resamplingGamma,
 		IsTerrarium:      format == "terrarium",
 		FillColor:        fc,
 		MemoryLimitBytes: memoryLimitBytes,
@@ -341,7 +348,7 @@ func main() {
 	}
 
 	// Build description for PMTiles metadata.
-	description := buildDescription(sources, mergedBounds, gaps, format, quality, tileSize, minZoom, maxZoom, resampling, fc, bandCfg)
+	description := buildDescription(sources, mergedBounds, gaps, format, quality, tileSize, minZoom, maxZoom, resampling, resamplingGamma, fc, bandCfg)
 
 	// Create PMTiles writer.
 	writer, err := pmtiles.NewWriter(outputPath, pmtiles.WriterOptions{
@@ -414,7 +421,7 @@ func isTIFF(name string) bool {
 }
 
 func buildDescription(sources []*cog.Reader, mergedBounds cog.Bounds, gaps []cog.CoverageGap,
-	format string, quality int, tileSize int, minZoom, maxZoom int, resampling string, fc *color.RGBA, bandCfg cog.BandConfig) string {
+	format string, quality int, tileSize int, minZoom, maxZoom int, resampling string, resamplingGamma float64, fc *color.RGBA, bandCfg cog.BandConfig) string {
 
 	var b strings.Builder
 
@@ -427,7 +434,11 @@ func buildDescription(sources []*cog.Reader, mergedBounds cog.Bounds, gaps []cog
 	}
 	b.WriteString(fmt.Sprintf("  Tile size: %dpx\n", tileSize))
 	b.WriteString(fmt.Sprintf("  Zoom: %d - %d\n", minZoom, maxZoom))
-	b.WriteString(fmt.Sprintf("  Resampling: %s\n", resampling))
+	if resamplingGamma != 1.0 {
+		b.WriteString(fmt.Sprintf("  Resampling: %s (gamma %.2g)\n", resampling, resamplingGamma))
+	} else {
+		b.WriteString(fmt.Sprintf("  Resampling: %s\n", resampling))
+	}
 	if fc != nil {
 		b.WriteString(fmt.Sprintf("  Fill color: rgba(%d,%d,%d,%d)\n", fc.R, fc.G, fc.B, fc.A))
 	}

--- a/cmd/pmtransform/main.go
+++ b/cmd/pmtransform/main.go
@@ -28,23 +28,24 @@ var (
 
 func main() {
 	var (
-		format      string
-		quality     int
-		minZoom     int
-		maxZoom     int
-		showVersion bool
-		tileSize    int
-		concurrency int
-		verbose     bool
-		resampling  string
-		cpuProfile  string
-		memProfile  string
-		memLimitMB  int
-		noSpill     bool
-		fillColor   string
-		rebuild     bool
-		attribution string
-		layerType   string
+		format          string
+		quality         int
+		minZoom         int
+		maxZoom         int
+		showVersion     bool
+		tileSize        int
+		concurrency     int
+		verbose         bool
+		resampling      string
+		cpuProfile      string
+		memProfile      string
+		memLimitMB      int
+		noSpill         bool
+		fillColor       string
+		rebuild         bool
+		attribution     string
+		layerType       string
+		resamplingGamma float64
 	)
 
 	flag.StringVar(&format, "format", "", "Target tile encoding: jpeg, png, webp (default: keep source format)")
@@ -54,6 +55,7 @@ func main() {
 	flag.IntVar(&tileSize, "tile-size", -1, "Output tile size in pixels (default: keep source)")
 	flag.IntVar(&concurrency, "concurrency", runtime.NumCPU(), "Number of parallel workers")
 	flag.StringVar(&resampling, "resampling", "bicubic", "Interpolation method: lanczos, bicubic, bilinear, nearest, mode")
+	flag.Float64Var(&resamplingGamma, "resampling-gamma", 1.0, "Gamma correction for resampling output encoding (1.0 = disabled, typical 1.5-2.2 for dB-space to RGB)")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose progress output")
 	flag.BoolVar(&showVersion, "version", false, "Print version and exit")
 	flag.StringVar(&cpuProfile, "cpuprofile", "", "Write CPU profile to file")
@@ -250,7 +252,11 @@ func main() {
 	fmt.Printf("  %-14s %d – %d (source: %d – %d)\n", "Zoom:",
 		minZoom, maxZoom, srcHeader.MinZoom, srcHeader.MaxZoom)
 	if mode == tile.TransformRebuild {
-		fmt.Printf("  %-14s %s\n", "Resampling:", resampling)
+		if resamplingGamma != 1.0 {
+			fmt.Printf("  %-14s %s (gamma %.2g)\n", "Resampling:", resampling, resamplingGamma)
+		} else {
+			fmt.Printf("  %-14s %s\n", "Resampling:", resampling)
+		}
 	}
 	fmt.Printf("  %-14s %d\n", "Concurrency:", concurrency)
 	if fc != nil {
@@ -277,6 +283,7 @@ func main() {
 		Encoder:          enc,
 		SourceFormat:     srcFormat,
 		Resampling:       resamplingMode,
+		ResamplingGamma:  resamplingGamma,
 		Mode:             mode,
 		FillColor:        fc,
 		Bounds:           bounds,
@@ -286,7 +293,7 @@ func main() {
 
 	// Build description with processing steps prepended to source description.
 	description := buildTransformDescription(srcDescription, srcHeader, mode, srcFormat, format, quality,
-		tileSize, minZoom, maxZoom, resampling, fc)
+		tileSize, minZoom, maxZoom, resampling, resamplingGamma, fc)
 
 	// Create PMTiles writer.
 	writer, err := pmtiles.NewWriter(outputPath, pmtiles.WriterOptions{
@@ -407,7 +414,7 @@ func parseHexColor(s string) (color.RGBA, error) {
 
 func buildTransformDescription(srcDescription string, srcHeader pmtiles.Header,
 	mode tile.TransformMode, srcFormat, targetFormat string, quality int,
-	tileSize, minZoom, maxZoom int, resampling string, fc *color.RGBA) string {
+	tileSize, minZoom, maxZoom int, resampling string, resamplingGamma float64, fc *color.RGBA) string {
 
 	var b strings.Builder
 
@@ -442,7 +449,11 @@ func buildTransformDescription(srcDescription string, srcHeader pmtiles.Header,
 	}
 
 	if mode == tile.TransformRebuild {
-		b.WriteString(fmt.Sprintf("  Resampling: %s\n", resampling))
+		if resamplingGamma != 1.0 {
+			b.WriteString(fmt.Sprintf("  Resampling: %s (gamma %.2g)\n", resampling, resamplingGamma))
+		} else {
+			b.WriteString(fmt.Sprintf("  Resampling: %s\n", resampling))
+		}
 	}
 
 	if fc != nil {

--- a/internal/tile/generator.go
+++ b/internal/tile/generator.go
@@ -75,6 +75,7 @@ type Config struct {
 	Encoder          encode.Encoder
 	Bounds           cog.Bounds
 	Resampling       Resampling
+	ResamplingGamma  float64     // power-law gamma for resampling interpolation (1.0 = disabled)
 	IsTerrarium      bool        // true for float GeoTIFF → Terrarium encoding
 	FillColor        *color.RGBA // when set, transparent/nodata pixels → fill color; missing tiles → solid fill
 	MemoryLimitBytes int64       // max tile store memory before disk spilling (0 = auto)
@@ -150,6 +151,13 @@ func Generate(cfg Config, sources []*cog.Reader, writer TileWriter) (Stats, erro
 	defer store.Close()
 
 	var tileCount, emptyCount, uniformCount, grayCount, totalBytes atomic.Int64
+
+	// Build gamma lookup tables for resampling interpolation.
+	// nil when gamma correction is disabled (gamma == 1.0 or terrarium mode).
+	var resamplingLUTs *gammaLUTs
+	if !cfg.IsTerrarium {
+		resamplingLUTs = buildGammaLUTs(cfg.ResamplingGamma)
+	}
 
 	// Pre-encode the fill-color tile once so identical fill tiles across all
 	// zoom levels reuse the same encoded bytes, skipping repeated encoder calls.
@@ -262,7 +270,7 @@ func Generate(cfg Config, sources []*cog.Reader, writer TileWriter) (Stats, erro
 							if cfg.IsTerrarium {
 								img = renderTileTerrarium(z, x, y, cfg.TileSize, srcInfos, proj, floatCache, cfg.Resampling)
 							} else {
-								img = renderTile(z, x, y, cfg.TileSize, srcInfos, proj, cogCache, cfg.Resampling)
+								img = renderTile(z, x, y, cfg.TileSize, srcInfos, proj, cogCache, cfg.Resampling, resamplingLUTs)
 							}
 							if img != nil {
 								if cfg.FillColor != nil {

--- a/internal/tile/resample.go
+++ b/internal/tile/resample.go
@@ -137,7 +137,7 @@ func tileCRSBounds(z, tx, ty int, proj coord.Projection) (minX, minY, maxX, maxY
 // and latitude per row. In web Mercator tiles, longitude is perfectly linear
 // with pixel X and latitude depends only on pixel Y, so we reduce trig calls
 // from O(tileSize²) to O(tileSize).
-func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Projection, cache *cog.TileCache, mode Resampling) *image.RGBA {
+func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Projection, cache *cog.TileCache, mode Resampling, luts *gammaLUTs) *image.RGBA {
 	// Pre-compute the output pixel size in CRS units for selecting the best overview level.
 	_, midLat, _, _ := coord.TileBounds(z, tx, ty)
 	outputResMeters := coord.ResolutionAtLat(midLat, z, tileSize)
@@ -175,7 +175,7 @@ func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Proje
 			// Convert precomputed WGS84 to source CRS.
 			srcX, srcY := proj.FromWGS84(lons[px], lat)
 
-			r, g, b, a, found := sampleFromTileSources(tileSrcs, srcX, srcY, cache, mode)
+			r, g, b, a, found := sampleFromTileSources(tileSrcs, srcX, srcY, cache, mode, luts)
 			if found {
 				off := rowOff + px*4
 				img.Pix[off+0] = r
@@ -200,7 +200,7 @@ func renderTile(z, tx, ty, tileSize int, srcInfos []sourceInfo, proj coord.Proje
 // sampleFromTileSources tries each pre-filtered tile source to sample a pixel
 // at the given CRS coordinates. Uses pre-computed overview levels and dimensions
 // to avoid redundant per-pixel computation.
-func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.TileCache, mode Resampling) (r, g, b, a uint8, found bool) {
+func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.TileCache, mode Resampling, luts *gammaLUTs) (r, g, b, a uint8, found bool) {
 	for i := range sources {
 		src := &sources[i]
 
@@ -225,11 +225,11 @@ func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.
 		case ResamplingNearest, ResamplingMode:
 			rr, gg, bb, aa, err = nearestSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
 		case ResamplingLanczos:
-			rr, gg, bb, aa, err = lanczosSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
+			rr, gg, bb, aa, err = lanczosSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache, luts)
 		case ResamplingBicubic:
-			rr, gg, bb, aa, err = bicubicSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
+			rr, gg, bb, aa, err = bicubicSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache, luts)
 		default:
-			rr, gg, bb, aa, err = bilinearSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache)
+			rr, gg, bb, aa, err = bilinearSampleCached(src.reader, src.level, pixX, pixY, src.imgW, src.imgH, src.tileW, src.tileH, cache, luts)
 		}
 
 		if err != nil {
@@ -268,7 +268,7 @@ func nearestSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH,
 // Optimized to do at most 2 cache lookups (instead of 4): pixels in the same
 // source tile are extracted directly from the already-fetched image.
 // tw and th are the source tile dimensions (pre-computed by prepareTileSources).
-func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
+func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	x0 := int(math.Floor(fx))
 	y0 := int(math.Floor(fy))
 	x1 := x0 + 1
@@ -385,6 +385,9 @@ func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH
 	gVal := (w00*float64(p00[1]) + w10*float64(p10[1]) + w01*float64(p01[1]) + w11*float64(p11[1])) / wSum
 	bVal := (w00*float64(p00[2]) + w10*float64(p10[2]) + w01*float64(p01[2]) + w11*float64(p11[2])) / wSum
 
+	if luts != nil {
+		return luts.encode(rVal), luts.encode(gVal), luts.encode(bVal), clampByte(aVal), nil
+	}
 	return clampByte(rVal), clampByte(gVal), clampByte(bVal), clampByte(aVal), nil
 }
 
@@ -403,7 +406,7 @@ func bilinearSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH
 // When all 36 pixels fall within a single YCbCr tile (the common case for JPEG
 // COGs), a specialized fast path avoids per-pixel type assertions and method
 // calls, inlining YCbCr offset computation and RGB conversion directly.
-func lanczosSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
+func lanczosSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	const a = 3
 	const n = 2 * a
 
@@ -444,21 +447,21 @@ func lanczosSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH,
 
 		// Try YCbCr fast path (most common for JPEG COGs).
 		if ycbcr, ok := tile.(*image.YCbCr); ok {
-			return lanczosAccumYCbCr(ycbcr, wxArr, wyArr, localX, localY)
+			return lanczosAccumYCbCr(ycbcr, wxArr, wyArr, localX, localY, luts)
 		}
 
 		// Try NYCbCrA fast path (JPEG with alpha).
 		if nycbcra, ok := tile.(*image.NYCbCrA); ok {
-			return lanczosAccumNYCbCrA(nycbcra, wxArr, wyArr, localX, localY)
+			return lanczosAccumNYCbCrA(nycbcra, wxArr, wyArr, localX, localY, luts)
 		}
 
 		// Try RGBA fast path (PNG tiles).
 		if rgba, ok := tile.(*image.RGBA); ok {
-			return lanczosAccumRGBA(rgba, wxArr, wyArr, localX, localY)
+			return lanczosAccumRGBA(rgba, wxArr, wyArr, localX, localY, luts)
 		}
 
 		// Generic fallback for single tile.
-		return lanczosAccumGeneric(tile, wxArr, wyArr, localX, localY)
+		return lanczosAccumGeneric(tile, wxArr, wyArr, localX, localY, luts)
 	}
 
 	// Multi-tile path: fetch the unique tiles (at most 2×2 = 4).
@@ -520,13 +523,16 @@ func lanczosSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH,
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
 // lanczosAccumYCbCr is the hot inner loop for Lanczos-3 on YCbCr tiles.
 // Type assertion and stride lookups happen once; per-pixel work is pure
 // integer arithmetic with no interface dispatch.
-func lanczosAccumYCbCr(img *image.YCbCr, wxArr, wyArr [6]float64, lx, ly [6]int) (uint8, uint8, uint8, uint8, error) {
+func lanczosAccumYCbCr(img *image.YCbCr, wxArr, wyArr [6]float64, lx, ly [6]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	yStride := img.YStride
 	cStride := img.CStride
 	ratio := img.SubsampleRatio
@@ -604,11 +610,14 @@ func lanczosAccumYCbCr(img *image.YCbCr, wxArr, wyArr [6]float64, lx, ly [6]int)
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wTotal), luts.encode(gSum / wTotal), luts.encode(bSum / wTotal), 255, nil
+	}
 	return clampByte(rSum / wTotal), clampByte(gSum / wTotal), clampByte(bSum / wTotal), 255, nil
 }
 
 // lanczosAccumNYCbCrA is the hot inner loop for Lanczos-3 on NYCbCrA tiles.
-func lanczosAccumNYCbCrA(img *image.NYCbCrA, wxArr, wyArr [6]float64, lx, ly [6]int) (uint8, uint8, uint8, uint8, error) {
+func lanczosAccumNYCbCrA(img *image.NYCbCrA, wxArr, wyArr [6]float64, lx, ly [6]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	yStride := img.YStride
 	cStride := img.CStride
 	aStride := img.AStride
@@ -696,11 +705,14 @@ func lanczosAccumNYCbCrA(img *image.NYCbCrA, wxArr, wyArr [6]float64, lx, ly [6]
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
 // lanczosAccumRGBA is the hot inner loop for Lanczos-3 on RGBA tiles.
-func lanczosAccumRGBA(img *image.RGBA, wxArr, wyArr [6]float64, lx, ly [6]int) (uint8, uint8, uint8, uint8, error) {
+func lanczosAccumRGBA(img *image.RGBA, wxArr, wyArr [6]float64, lx, ly [6]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	pix := img.Pix
 	stride := img.Stride
 
@@ -736,11 +748,14 @@ func lanczosAccumRGBA(img *image.RGBA, wxArr, wyArr [6]float64, lx, ly [6]int) (
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
 // lanczosAccumGeneric is a fallback for rare tile types using the image.Image interface.
-func lanczosAccumGeneric(tile image.Image, wxArr, wyArr [6]float64, lx, ly [6]int) (uint8, uint8, uint8, uint8, error) {
+func lanczosAccumGeneric(tile image.Image, wxArr, wyArr [6]float64, lx, ly [6]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	var rSum, gSum, bSum, aSum, wTotal, wRGB float64
 
 	for ky := 0; ky < 6; ky++ {
@@ -770,6 +785,9 @@ func lanczosAccumGeneric(tile image.Image, wxArr, wyArr [6]float64, lx, ly [6]in
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
@@ -778,7 +796,7 @@ func lanczosAccumGeneric(tile image.Image, wxArr, wyArr [6]float64, lx, ly [6]in
 // ringing than Lanczos-3. Pixels with alpha == 0 are excluded from RGB
 // interpolation. Optimized with batched tile fetches: the 4×4 neighborhood
 // spans at most 2×2 source tiles.
-func bicubicSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache) (uint8, uint8, uint8, uint8, error) {
+func bicubicSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH, tw, th int, cache *cog.TileCache, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	const n = 4
 
 	ix0 := int(math.Floor(fx)) - 1
@@ -811,15 +829,15 @@ func bicubicSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH,
 			return 0, 0, 0, 0, err
 		}
 		if ycbcr, ok := tile.(*image.YCbCr); ok {
-			return bicubicAccumYCbCr(ycbcr, wxArr, wyArr, localX, localY)
+			return bicubicAccumYCbCr(ycbcr, wxArr, wyArr, localX, localY, luts)
 		}
 		if nycbcra, ok := tile.(*image.NYCbCrA); ok {
-			return bicubicAccumNYCbCrA(nycbcra, wxArr, wyArr, localX, localY)
+			return bicubicAccumNYCbCrA(nycbcra, wxArr, wyArr, localX, localY, luts)
 		}
 		if rgba, ok := tile.(*image.RGBA); ok {
-			return bicubicAccumRGBA(rgba, wxArr, wyArr, localX, localY)
+			return bicubicAccumRGBA(rgba, wxArr, wyArr, localX, localY, luts)
 		}
-		return bicubicAccumGeneric(tile, wxArr, wyArr, localX, localY)
+		return bicubicAccumGeneric(tile, wxArr, wyArr, localX, localY, luts)
 	}
 
 	// Multi-tile path: fetch the unique tiles (at most 2×2 = 4).
@@ -877,11 +895,14 @@ func bicubicSampleCached(src *cog.Reader, level int, fx, fy float64, imgW, imgH,
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
 // bicubicAccumYCbCr is the inner loop for bicubic on YCbCr tiles.
-func bicubicAccumYCbCr(img *image.YCbCr, wxArr, wyArr [4]float64, lx, ly [4]int) (uint8, uint8, uint8, uint8, error) {
+func bicubicAccumYCbCr(img *image.YCbCr, wxArr, wyArr [4]float64, lx, ly [4]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	yStride := img.YStride
 	cStride := img.CStride
 	ratio := img.SubsampleRatio
@@ -959,11 +980,14 @@ func bicubicAccumYCbCr(img *image.YCbCr, wxArr, wyArr [4]float64, lx, ly [4]int)
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wTotal), luts.encode(gSum / wTotal), luts.encode(bSum / wTotal), 255, nil
+	}
 	return clampByte(rSum / wTotal), clampByte(gSum / wTotal), clampByte(bSum / wTotal), 255, nil
 }
 
 // bicubicAccumNYCbCrA is the inner loop for bicubic on NYCbCrA tiles.
-func bicubicAccumNYCbCrA(img *image.NYCbCrA, wxArr, wyArr [4]float64, lx, ly [4]int) (uint8, uint8, uint8, uint8, error) {
+func bicubicAccumNYCbCrA(img *image.NYCbCrA, wxArr, wyArr [4]float64, lx, ly [4]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	yStride := img.YStride
 	cStride := img.CStride
 	aStride := img.AStride
@@ -1051,11 +1075,14 @@ func bicubicAccumNYCbCrA(img *image.NYCbCrA, wxArr, wyArr [4]float64, lx, ly [4]
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
 // bicubicAccumRGBA is the inner loop for bicubic on RGBA tiles.
-func bicubicAccumRGBA(img *image.RGBA, wxArr, wyArr [4]float64, lx, ly [4]int) (uint8, uint8, uint8, uint8, error) {
+func bicubicAccumRGBA(img *image.RGBA, wxArr, wyArr [4]float64, lx, ly [4]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	pix := img.Pix
 	stride := img.Stride
 
@@ -1091,11 +1118,14 @@ func bicubicAccumRGBA(img *image.RGBA, wxArr, wyArr [4]float64, lx, ly [4]int) (
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
 // bicubicAccumGeneric is a fallback for rare tile types using the image.Image interface.
-func bicubicAccumGeneric(tile image.Image, wxArr, wyArr [4]float64, lx, ly [4]int) (uint8, uint8, uint8, uint8, error) {
+func bicubicAccumGeneric(tile image.Image, wxArr, wyArr [4]float64, lx, ly [4]int, luts *gammaLUTs) (uint8, uint8, uint8, uint8, error) {
 	var rSum, gSum, bSum, aSum, wTotal, wRGB float64
 
 	for ky := 0; ky < 4; ky++ {
@@ -1125,6 +1155,9 @@ func bicubicAccumGeneric(tile image.Image, wxArr, wyArr [4]float64, lx, ly [4]in
 		return 0, 0, 0, 0, nil
 	}
 
+	if luts != nil {
+		return luts.encode(rSum / wRGB), luts.encode(gSum / wRGB), luts.encode(bSum / wRGB), clampByte(aSum / wTotal), nil
+	}
 	return clampByte(rSum / wRGB), clampByte(gSum / wRGB), clampByte(bSum / wRGB), clampByte(aSum / wTotal), nil
 }
 
@@ -1366,6 +1399,48 @@ func bicubicLUT(x float64) float64 {
 	}
 	frac := pos - float64(idx)
 	return bicubicTable[idx]*(1-frac) + bicubicTable[idx+1]*frac
+}
+
+// gammaEncodeSize is the number of entries in the gamma encode table.
+// 4096 entries give ~0.06 precision per step, well below the uint8 quantization
+// threshold of ~0.5.
+const gammaEncodeSize = 4096
+
+// gammaLUTs holds a precomputed lookup table for power-law gamma encoding
+// applied after resampling interpolation. The interpolation itself operates
+// on the raw source pixel values (no decode step); the encode table maps
+// the interpolated [0..255] result to a gamma-corrected output byte.
+//
+// Alpha is never gamma-corrected — it is linear by definition.
+type gammaLUTs struct {
+	toGamma [gammaEncodeSize]uint8 // interpolated [0..gammaEncodeSize-1] → gamma-encoded uint8
+}
+
+// buildGammaLUTs creates a gamma encode lookup table for the given exponent.
+// Returns nil when gamma correction is disabled (gamma ≤ 0 or gamma == 1.0).
+func buildGammaLUTs(gamma float64) *gammaLUTs {
+	if gamma <= 0 || gamma == 1.0 {
+		return nil
+	}
+	luts := &gammaLUTs{}
+	invGamma := 1.0 / gamma
+	for i := 0; i < gammaEncodeSize; i++ {
+		luts.toGamma[i] = uint8(math.Round(math.Pow(float64(i)/float64(gammaEncodeSize-1), invGamma) * 255.0))
+	}
+	return luts
+}
+
+// encode converts an interpolated value (in [0..255] scale) to a
+// gamma-encoded byte via table lookup.
+func (g *gammaLUTs) encode(v float64) uint8 {
+	if v <= 0 {
+		return 0
+	}
+	if v >= 255 {
+		return 255
+	}
+	idx := int(v * float64(gammaEncodeSize-1) / 255.0)
+	return g.toGamma[idx]
 }
 
 // renderTileTerrarium renders a single web map tile from float GeoTIFF data,

--- a/internal/tile/resample_test.go
+++ b/internal/tile/resample_test.go
@@ -5,6 +5,72 @@ import (
 	"testing"
 )
 
+// --- gamma LUTs ---
+
+func TestBuildGammaLUTs_NilCases(t *testing.T) {
+	// Disabled when gamma <= 0 or == 1.0.
+	for _, g := range []float64{0, -1, 1.0} {
+		if luts := buildGammaLUTs(g); luts != nil {
+			t.Errorf("buildGammaLUTs(%v) = non-nil, want nil", g)
+		}
+	}
+}
+
+func TestBuildGammaLUTs_NonNil(t *testing.T) {
+	luts := buildGammaLUTs(2.2)
+	if luts == nil {
+		t.Fatal("buildGammaLUTs(2.2) = nil, want non-nil")
+	}
+}
+
+func TestGammaLUTs_EncodeBounds(t *testing.T) {
+	luts := buildGammaLUTs(2.2)
+	if luts == nil {
+		t.Fatal("buildGammaLUTs(2.2) = nil")
+	}
+	// Endpoints must be exact.
+	if v := luts.encode(0); v != 0 {
+		t.Errorf("encode(0) = %d, want 0", v)
+	}
+	if v := luts.encode(255); v != 255 {
+		t.Errorf("encode(255) = %d, want 255", v)
+	}
+	// Negative and overflow clamp.
+	if v := luts.encode(-10); v != 0 {
+		t.Errorf("encode(-10) = %d, want 0", v)
+	}
+	if v := luts.encode(300); v != 255 {
+		t.Errorf("encode(300) = %d, want 255", v)
+	}
+}
+
+func TestGammaLUTs_EncodeBrightensMidtones(t *testing.T) {
+	// With gamma > 1, encode(v) = v^(1/gamma)*255 should produce
+	// brighter (higher) output for midtone inputs.
+	luts := buildGammaLUTs(2.2)
+	if luts == nil {
+		t.Fatal("buildGammaLUTs(2.2) = nil")
+	}
+	mid := luts.encode(128)
+	if mid <= 128 {
+		t.Errorf("encode(128) = %d, want > 128 (gamma encode should brighten midtones)", mid)
+	}
+}
+
+func TestGammaLUTs_EncodeMonotonic(t *testing.T) {
+	luts := buildGammaLUTs(2.2)
+	if luts == nil {
+		t.Fatal("buildGammaLUTs(2.2) = nil")
+	}
+	// The encode table must be monotonically non-decreasing.
+	for i := 1; i < gammaEncodeSize; i++ {
+		if luts.toGamma[i] < luts.toGamma[i-1] {
+			t.Fatalf("toGamma[%d]=%d < toGamma[%d]=%d: not monotonic",
+				i, luts.toGamma[i], i-1, luts.toGamma[i-1])
+		}
+	}
+}
+
 // --- clamp ---
 
 func TestClamp(t *testing.T) {

--- a/internal/tile/transform.go
+++ b/internal/tile/transform.go
@@ -37,6 +37,7 @@ type TransformConfig struct {
 	Encoder          encode.Encoder
 	SourceFormat     string // format of input tiles (for decoding)
 	Resampling       Resampling
+	ResamplingGamma  float64 // power-law gamma for resampling interpolation (1.0 = disabled)
 	Mode             TransformMode
 	FillColor        *color.RGBA
 	Bounds           [4]float32 // MinLon, MinLat, MaxLon, MaxLat


### PR DESCRIPTION
Add `--resampling-gamma` flag to geotiff2pmtiles and pmtransform for gamma-corrected
output encoding after resampling interpolation. Useful for brightening midtones when
converting from dB-space (e.g. SAR backscatter) to RGB for display.

Gamma is applied after interpolation in bilinear, Lanczos-3, and bicubic resampling. The encode-only approach keeps accumulation in source value space with a 4096-entry LUT for the output mapping. Default 1.0 (disabled); 2.2 recommended for sRGB content. Alpha is never gamma-corrected.

Adds flag to both geotiff2pmtiles and pmtransform, with gamma shown in startup config output and PMTiles metadata when non-default.