### PR TITLE
Optimize transform rebuild with fill-color for sparse tiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,6 +84,11 @@ rebuild, transparent pixels in decoded tiles and nil-child quadrants in downsamp
 tiles become the fill color. Additionally, solid-color tiles are generated for tile
 positions within bounds that have no data.
 
+For sparse datasets, rebuild tracks which positions contain real (non-fill) data and
+propagates upward through zoom levels. Only real positions go through the expensive
+downsample/encode pipeline; all-fill positions get pre-encoded bytes written directly,
+skipping DiskTileStore overhead entirely.
+
 ## Memory Efficiency
 
 - Memory-mapped file access (no full-image decode)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -343,6 +343,24 @@ The CLI tries auto-detection in `parseBandConfig` only when `--rescale auto` (de
 16-bit data, no explicit `--rescale-range`, and no explicit `--bands` override. Explicit
 flags always take precedence.
 
+## Transform rebuild: sparse fill optimization
+
+When `pmtransform --rebuild --fill-color` processes sparse datasets, most tile
+positions in bounds contain no source data and produce identical fill tiles. Rather
+than processing every position through the full downsample → encode → store pipeline,
+positions are partitioned into "real" (need decode/downsample/encode) and "fill" (write
+pre-encoded bytes directly).
+
+At max zoom, source tiles are "real" and all others get pre-encoded fill bytes written
+directly. At lower zooms, a parent is "real" iff at least one of its 4 children was real
+— propagated upward via a `realPositions` set. This reduces the expensive path from
+O(positions_in_bounds) to O(real_positions) per zoom level, and fill tiles never enter
+the DiskTileStore (avoiding 128 bytes of map overhead per entry).
+
+The fill tile is pre-encoded once before the zoom loop (matching the pattern in
+`generator.go`) and a shared immutable `fillTileShared` TileData replaces per-position
+allocations for nil-child substitution during downsampling.
+
 ## Integration test plausibility checks
 
 Satellite integration tests use a shared `assertPlausiblePMTiles` helper that validates

--- a/changes/2026-02-28-18-00-transform-fill-sparse-optimization.md
+++ b/changes/2026-02-28-18-00-transform-fill-sparse-optimization.md
@@ -1,0 +1,37 @@
+# Optimize transform rebuild with fill-color for sparse tiles
+
+## Problem
+
+`pmtransform --rebuild --fill-color` was extremely slow for sparse datasets.
+With fill-color, ALL tile positions in bounds were enumerated at every zoom
+level and processed through the full pipeline (DiskTileStore lookup, fill
+substitution, downsample, encode, write, store) even when 99%+ produced
+identical fill tiles.
+
+For a dataset with 1K source tiles covering 1M positions at zoom 14, this
+meant ~999K redundant encode calls, ~999K DiskTileStore entries (128 bytes
+overhead each), and the cascade multiplied through every lower zoom level.
+
+## Solution
+
+Track which positions contain real (non-fill) data and propagate upward:
+
+1. **Pre-encode fill tile once** before the zoom loop. Reuse the same encoded
+   bytes for all fill positions, skipping repeated encoder calls.
+
+2. **Partition tiles at each zoom level**: At max zoom, source tiles are "real"
+   and everything else gets pre-encoded fill bytes written directly. At lower
+   zooms, a parent is "real" iff at least one of its 4 children was real.
+   All-fill parents get pre-encoded bytes without entering the downsample
+   pipeline.
+
+3. **Shared fillTileShared**: A single immutable uniform TileData replaces
+   per-position allocations. Used for nil-child substitution in the downsample
+   path and for the rare case where a source tile returns no data.
+
+Fill tiles never enter DiskTileStore, eliminating map overhead for empty
+positions. Only real tiles go through the worker pool.
+
+## Files changed
+
+- `internal/tile/transform.go` — `transformRebuild` function

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -454,6 +454,7 @@ type transformConfig struct {
 	Resampling  string
 	Rebuild     bool
 	Concurrency int
+	FillColor   *color.RGBA
 }
 
 // runTransform executes the PMTiles transform pipeline and returns the output path.
@@ -519,6 +520,8 @@ func runTransform(t *testing.T, cfg transformConfig) string {
 		mode = tile.TransformRebuild
 	} else if formatChanged {
 		mode = tile.TransformReencode
+	} else if cfg.FillColor != nil {
+		mode = tile.TransformReencode
 	}
 
 	bounds := [4]float32{srcHeader.MinLon, srcHeader.MinLat, srcHeader.MaxLon, srcHeader.MaxLat}
@@ -533,6 +536,7 @@ func runTransform(t *testing.T, cfg transformConfig) string {
 		SourceFormat: srcFormat,
 		Resampling:   resamplingMode,
 		Mode:         mode,
+		FillColor:    cfg.FillColor,
 		Bounds:       bounds,
 		OutputDir:    outputDir,
 	}

--- a/integration/synthetic_test.go
+++ b/integration/synthetic_test.go
@@ -484,6 +484,132 @@ func TestTransformRebuild(t *testing.T) {
 	}
 }
 
+// TestTransformRebuildWithFillColor creates a sparse PMTiles at zoom 2-3
+// and rebuilds with fill-color, verifying that all positions within bounds
+// are populated and tile counts increase relative to the no-fill source.
+func TestTransformRebuildWithFillColor(t *testing.T) {
+	// Create a small GeoTIFF covering a limited area (sparse in tile space).
+	tiffPath := writeSyntheticGeoTIFF(t, tiffWriterConfig{
+		Width: 256, Height: 256,
+		SamplesPerPixel: 3,
+		BitsPerSample:   8,
+		OriginLon:       8.0,
+		OriginLat:       47.5,
+		PixelSizeDeg:    0.01, // ~2.56° extent
+		EPSG:            4326,
+		PixelFunc: func(x, y, band int) uint16 {
+			return uint16((x*3 + y*7 + band*11) % 256)
+		},
+	})
+
+	srcPath := runPipeline(t, pipelineConfig{
+		InputPaths: []string{tiffPath},
+		Format:     "png",
+		MinZoom:    2,
+		MaxZoom:    4,
+	})
+
+	srcResult := validatePMTiles(t, srcPath)
+	if srcResult.TileCount == 0 {
+		t.Fatal("source should have tiles")
+	}
+
+	fill := &color.RGBA{R: 128, G: 0, B: 128, A: 255}
+	outPath := runTransform(t, transformConfig{
+		InputPath: srcPath,
+		MinZoom:   0,
+		MaxZoom:   -1,
+		Rebuild:   true,
+		FillColor: fill,
+	})
+
+	outResult := validatePMTiles(t, outPath)
+
+	// With fill-color and rebuild to zoom 0, the output should have more
+	// tiles than the source (lower zoom levels added by rebuild).
+	if outResult.TileCount <= srcResult.TileCount {
+		t.Errorf("fill-color output (%d tiles) should exceed source (%d tiles)",
+			outResult.TileCount, srcResult.TileCount)
+	}
+
+	// Zoom 0 and 1 should exist (rebuilt from max zoom via downsampling).
+	if outResult.ZoomCounts[0] == 0 {
+		t.Error("expected tiles at zoom 0 after rebuild with fill-color")
+	}
+	if outResult.ZoomCounts[1] == 0 {
+		t.Error("expected tiles at zoom 1 after rebuild with fill-color")
+	}
+
+	// Max zoom should have at least as many tiles as source.
+	maxZ := int(srcResult.Header.MaxZoom)
+	if outResult.ZoomCounts[maxZ] < srcResult.ZoomCounts[maxZ] {
+		t.Errorf("zoom %d: fill output (%d) should be >= source (%d)",
+			maxZ, outResult.ZoomCounts[maxZ], srcResult.ZoomCounts[maxZ])
+	}
+}
+
+// TestTransformRebuildWithFillColor_Sparse creates a small GeoTIFF within a
+// large bounding box, converts to PMTiles, then rebuilds with fill-color.
+// This exercises the sparse fill optimization: at max zoom most positions
+// are empty and should be filled with pre-encoded bytes.
+func TestTransformRebuildWithFillColor_Sparse(t *testing.T) {
+	// Small 256x256 image covering ~25° extent → at zoom 3, multiple tile
+	// positions in bounds but only a few have actual source data.
+	tiffPath := writeSyntheticGeoTIFF(t, tiffWriterConfig{
+		Width: 256, Height: 256,
+		SamplesPerPixel: 3,
+		BitsPerSample:   8,
+		OriginLon:       -25.0,
+		OriginLat:       70.0,
+		PixelSizeDeg:    0.1, // 25.6° extent
+		EPSG:            4326,
+		PixelFunc: func(x, y, band int) uint16 {
+			return uint16((x*5 + y*3 + band*7) % 256)
+		},
+	})
+
+	srcPath := runPipeline(t, pipelineConfig{
+		InputPaths: []string{tiffPath},
+		Format:     "png",
+		MinZoom:    2,
+		MaxZoom:    3,
+	})
+
+	srcResult := validatePMTiles(t, srcPath)
+	srcMaxZoom := int(srcResult.Header.MaxZoom)
+
+	fill := &color.RGBA{R: 0, G: 0, B: 0, A: 255}
+	outPath := runTransform(t, transformConfig{
+		InputPath: srcPath,
+		MinZoom:   0,
+		MaxZoom:   -1,
+		Rebuild:   true,
+		FillColor: fill,
+	})
+
+	outResult := validatePMTiles(t, outPath)
+
+	// Fill-color output should have more total tiles (lower zooms + filled gaps).
+	if outResult.TileCount <= srcResult.TileCount {
+		t.Errorf("fill output (%d) should exceed source (%d)",
+			outResult.TileCount, srcResult.TileCount)
+	}
+
+	// At max zoom, fill should produce at least as many tiles as source
+	// (more if source bounds have gaps).
+	if outResult.ZoomCounts[srcMaxZoom] < srcResult.ZoomCounts[srcMaxZoom] {
+		t.Errorf("zoom %d: fill output (%d) should be >= source (%d)",
+			srcMaxZoom, outResult.ZoomCounts[srcMaxZoom], srcResult.ZoomCounts[srcMaxZoom])
+	}
+
+	// Lower zoom levels added by rebuild should all be populated.
+	for z := 0; z < int(srcResult.Header.MinZoom); z++ {
+		if outResult.ZoomCounts[z] == 0 {
+			t.Errorf("zoom %d should have tiles after rebuild with fill", z)
+		}
+	}
+}
+
 // TestWebPEncoding generates a 512x512 8-bit RGB GeoTIFF and converts to WebP.
 // Skipped if CGO/libwebp is not available.
 func TestWebPEncoding(t *testing.T) {

--- a/internal/tile/transform.go
+++ b/internal/tile/transform.go
@@ -314,35 +314,122 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 		}
 	}
 
+	// Pre-encode the fill tile once so identical fill tiles across all
+	// zoom levels reuse the same encoded bytes, skipping repeated encoder
+	// calls and avoiding DiskTileStore overhead for fill positions.
+	var (
+		fillTileShared *TileData // shared uniform fill tile (immutable, safe to share)
+		fillEncoded    []byte    // pre-encoded bytes for the fill tile
+	)
+	if cfg.FillColor != nil {
+		fillTileShared = newTileDataUniform(*cfg.FillColor, cfg.TileSize)
+		var encErr error
+		fillEncoded, encErr = cfg.Encoder.Encode(fillTileShared.AsImage())
+		if encErr != nil {
+			return Stats{}, fmt.Errorf("encoding fill color tile: %w", encErr)
+		}
+	}
+
+	// Track positions with real (non-fill) data at each zoom level.
+	// A parent position is "real" iff at least one of its 4 children was real.
+	// All-fill parents are written directly with pre-encoded bytes, skipping
+	// the expensive downsample → encode → store pipeline.
+	var realPositions map[[2]int]bool
+
 	for z := effectiveMaxZoom; z >= cfg.MinZoom; z-- {
 		isMaxZoom := (z == effectiveMaxZoom)
 
-		var tiles [][3]int
+		// Partition tiles into realTiles (need decode/downsample/encode)
+		// and fill tiles (write pre-encoded bytes directly).
+		var realTiles [][3]int
+		var nFillTiles int64
+
 		if isMaxZoom && cfg.FillColor == nil {
-			tiles = reader.TilesAtZoom(z)
+			// No fill — only process existing source tiles.
+			realTiles = reader.TilesAtZoom(z)
+		} else if cfg.FillColor != nil {
+			allTiles := coord.TilesInBounds(z,
+				float64(cfg.Bounds[0]), float64(cfg.Bounds[1]),
+				float64(cfg.Bounds[2]), float64(cfg.Bounds[3]))
+
+			if isMaxZoom {
+				// Source tiles need full decode/encode; all others get
+				// pre-encoded fill bytes written directly.
+				realPositions = make(map[[2]int]bool, len(sourceTilesAtMax))
+				for pos := range sourceTilesAtMax {
+					realPositions[pos] = true
+				}
+				realTiles = make([][3]int, 0, len(sourceTilesAtMax))
+				for _, t := range allTiles {
+					if sourceTilesAtMax[[2]int{t[1], t[2]}] {
+						realTiles = append(realTiles, t)
+					} else {
+						if err := writer.WriteTile(t[0], t[1], t[2], fillEncoded); err != nil {
+							return Stats{}, fmt.Errorf("writing fill tile z%d/%d/%d: %w", t[0], t[1], t[2], err)
+						}
+						nFillTiles++
+					}
+				}
+			} else {
+				// A parent needs downsampling iff at least one child has real data.
+				nextReal := make(map[[2]int]bool)
+				for _, t := range allTiles {
+					x, y := t[1], t[2]
+					if realPositions[[2]int{2 * x, 2 * y}] ||
+						realPositions[[2]int{2*x + 1, 2 * y}] ||
+						realPositions[[2]int{2 * x, 2*y + 1}] ||
+						realPositions[[2]int{2*x + 1, 2*y + 1}] {
+						realTiles = append(realTiles, t)
+						nextReal[[2]int{x, y}] = true
+					} else {
+						if err := writer.WriteTile(t[0], t[1], t[2], fillEncoded); err != nil {
+							return Stats{}, fmt.Errorf("writing fill tile z%d/%d/%d: %w", t[0], t[1], t[2], err)
+						}
+						nFillTiles++
+					}
+				}
+				realPositions = nextReal
+			}
+
+			// Account for fill tiles in stats.
+			if nFillTiles > 0 {
+				tileCount.Add(nFillTiles)
+				uniformCount.Add(nFillTiles)
+				totalBytes.Add(nFillTiles * int64(len(fillEncoded)))
+			}
 		} else {
-			// Enumerate all positions from bounds. At max zoom with fill,
-			// this ensures gaps get fill tiles directly. At lower zooms,
-			// this allows downsampling even where the source had gaps.
-			tiles = coord.TilesInBounds(z,
+			// No fill, lower zoom — enumerate all positions from bounds.
+			realTiles = coord.TilesInBounds(z,
 				float64(cfg.Bounds[0]), float64(cfg.Bounds[1]),
 				float64(cfg.Bounds[2]), float64(cfg.Bounds[3]))
 		}
 
-		if len(tiles) == 0 {
+		if len(realTiles) == 0 && nFillTiles == 0 {
 			continue
 		}
 
+		totalAtZoom := int64(len(realTiles)) + nFillTiles
 		if cfg.Verbose {
-			log.Printf("Zoom %d: %d tiles to process", z, len(tiles))
+			if nFillTiles > 0 {
+				log.Printf("Zoom %d: %d tiles to process (%d real, %d fill)", z, totalAtZoom, len(realTiles), nFillTiles)
+			} else {
+				log.Printf("Zoom %d: %d tiles to process", z, totalAtZoom)
+			}
 		}
 
-		coord.SortTilesByHilbert(tiles)
+		pb := newProgressBar(fmt.Sprintf("Zoom %2d", z), totalAtZoom)
+		// Advance progress for fill tiles already written.
+		pb.processed.Add(nFillTiles)
 
-		pb := newProgressBar(fmt.Sprintf("Zoom %2d", z), int64(len(tiles)))
+		if len(realTiles) == 0 {
+			pb.Finish()
+			continue
+		}
+
+		coord.SortTilesByHilbert(realTiles)
 
 		nextStore := NewDiskTileStore(DiskTileStoreConfig{
-			InitialCapacity:  len(tiles),
+			InitialCapacity:  len(realTiles),
 			TileSize:         cfg.TileSize,
 			TempDir:          cfg.OutputDir,
 			MemoryLimitBytes: memLimit,
@@ -350,7 +437,7 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 			Verbose:          cfg.Verbose,
 		})
 
-		nTiles := len(tiles)
+		nTiles := len(realTiles)
 		nWorkers := cfg.Concurrency
 		if nWorkers > nTiles {
 			nWorkers = nTiles
@@ -374,7 +461,7 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 				if end > nTiles {
 					end = nTiles
 				}
-				batchCh <- tiles[i:end]
+				batchCh <- realTiles[i:end]
 			}
 			close(batchCh)
 		}()
@@ -390,8 +477,8 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 						var td *TileData
 
 						if isMaxZoom {
-							// When fill is set, check whether this position has
-							// a source tile or should be filled.
+							// All tiles in realTiles have source data when fill
+							// is active (fill-only positions already written).
 							hasSource := sourceTilesAtMax == nil || sourceTilesAtMax[[2]int{x, y}]
 							if hasSource {
 								rawData, err := reader.ReadTile(z, x, y)
@@ -419,7 +506,7 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 								}
 							}
 							if td == nil && cfg.FillColor != nil {
-								td = newTileDataUniform(*cfg.FillColor, cfg.TileSize)
+								td = fillTileShared
 							}
 						} else {
 							childZ := z + 1
@@ -427,21 +514,20 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 							tr := store.Get(childZ, 2*x+1, 2*y)
 							bl := store.Get(childZ, 2*x, 2*y+1)
 							br := store.Get(childZ, 2*x+1, 2*y+1)
-							// Color transform at source: substitute nil children with fill tiles
-							// so downsample operates on 4 tiles; no transform in downsample path.
-							if cfg.FillColor != nil {
-								fillTile := newTileDataUniform(*cfg.FillColor, cfg.TileSize)
+							// Substitute nil children with the shared fill tile
+							// so downsample operates on 4 tiles.
+							if fillTileShared != nil {
 								if tl == nil {
-									tl = fillTile
+									tl = fillTileShared
 								}
 								if tr == nil {
-									tr = fillTile
+									tr = fillTileShared
 								}
 								if bl == nil {
-									bl = fillTile
+									bl = fillTileShared
 								}
 								if br == nil {
-									br = fillTile
+									br = fillTileShared
 								}
 							}
 							td = downsampleTile(tl, tr, bl, br, cfg.TileSize, cfg.Resampling)
@@ -459,13 +545,21 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 							grayCount.Add(1)
 						}
 
-						data, err := cfg.Encoder.Encode(td.AsImage())
-						if err != nil {
-							select {
-							case errCh <- fmt.Errorf("encoding tile z%d/%d/%d: %w", z, x, y, err):
-							default:
+						// Use pre-encoded fill bytes for uniform fill tiles
+						// to skip redundant encoder calls.
+						var data []byte
+						if fillEncoded != nil && td == fillTileShared {
+							data = fillEncoded
+						} else {
+							var err error
+							data, err = cfg.Encoder.Encode(td.AsImage())
+							if err != nil {
+								select {
+								case errCh <- fmt.Errorf("encoding tile z%d/%d/%d: %w", z, x, y, err):
+								default:
+								}
+								return
 							}
-							return
 						}
 
 						if err := writer.WriteTile(z, x, y, data); err != nil {
@@ -480,7 +574,9 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 							nextStore.Put(z, x, y, td, data)
 						}
 
-						td.Release()
+						if td != fillTileShared {
+							td.Release()
+						}
 
 						tileCount.Add(1)
 						totalBytes.Add(int64(len(data)))
@@ -513,9 +609,6 @@ func transformRebuild(cfg TransformConfig, reader PMTilesReader, writer TileWrit
 	}
 
 	store.Close()
-
-	// No fillEmptyTiles needed: when FillColor is set, all positions
-	// (including gaps) are handled inline during the zoom loop above.
 
 	return Stats{
 		TileCount:    tileCount.Load(),

--- a/internal/tile/transform_test.go
+++ b/internal/tile/transform_test.go
@@ -1,0 +1,461 @@
+package tile
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"sync"
+	"testing"
+
+	"github.com/pspoerri/geotiff2pmtiles/internal/encode"
+	"github.com/pspoerri/geotiff2pmtiles/internal/pmtiles"
+)
+
+// --- Mock implementations ---
+
+// mockPMTilesReader implements PMTilesReader for unit testing.
+type mockPMTilesReader struct {
+	tiles  map[[3]int][]byte
+	header pmtiles.Header
+}
+
+func (r *mockPMTilesReader) ReadTile(z, x, y int) ([]byte, error) {
+	return r.tiles[[3]int{z, x, y}], nil
+}
+
+func (r *mockPMTilesReader) TilesAtZoom(z int) [][3]int {
+	var result [][3]int
+	for k := range r.tiles {
+		if k[0] == z {
+			result = append(result, k)
+		}
+	}
+	return result
+}
+
+func (r *mockPMTilesReader) Header() pmtiles.Header {
+	return r.header
+}
+
+// mockTileWriter collects written tiles for verification.
+type mockTileWriter struct {
+	mu    sync.Mutex
+	tiles map[[3]int][]byte
+}
+
+func newMockTileWriter() *mockTileWriter {
+	return &mockTileWriter{tiles: make(map[[3]int][]byte)}
+}
+
+func (w *mockTileWriter) WriteTile(z, x, y int, data []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.tiles[[3]int{z, x, y}] = append([]byte{}, data...)
+	return nil
+}
+
+func (w *mockTileWriter) tileCountAtZoom(z int) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	count := 0
+	for k := range w.tiles {
+		if k[0] == z {
+			count++
+		}
+	}
+	return count
+}
+
+// encodePNGTile creates a PNG-encoded tile image with the given color.
+func encodePNGTile(t *testing.T, tileSize int, c color.RGBA) []byte {
+	t.Helper()
+	enc, err := encode.NewEncoder("png", 0)
+	if err != nil {
+		t.Fatalf("NewEncoder(png): %v", err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, tileSize, tileSize))
+	pix := img.Pix
+	for i := 0; i < len(pix); i += 4 {
+		pix[i] = c.R
+		pix[i+1] = c.G
+		pix[i+2] = c.B
+		pix[i+3] = c.A
+	}
+	data, err := enc.Encode(img)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	return data
+}
+
+// --- Test setup ---
+//
+// Bounds (0, 0, 90, 45) produce these tile positions:
+//   Zoom 2: (2,2,1), (2,3,1), (2,2,2), (2,3,2)  — 4 tiles
+//   Zoom 1: (1,1,0), (1,1,1)                      — 2 tiles
+//   Zoom 0: (0,0,0)                                — 1 tile
+//
+// Parent mapping from zoom 2 to zoom 1:
+//   (2,2,1) and (2,3,1) → parent (1,1,0)
+//   (2,2,2) and (2,3,2) → parent (1,1,1)
+
+func testBounds() [4]float32 {
+	return [4]float32{0, 0, 90, 45}
+}
+
+func testEncoder(t *testing.T) encode.Encoder {
+	t.Helper()
+	enc, err := encode.NewEncoder("png", 0)
+	if err != nil {
+		t.Fatalf("NewEncoder: %v", err)
+	}
+	return enc
+}
+
+// --- Transform rebuild fill tests ---
+
+// TestTransformRebuild_FillColor_Sparse verifies that sparse source data
+// combined with fill-color produces tiles at all positions within bounds.
+func TestTransformRebuild_FillColor_Sparse(t *testing.T) {
+	tileSize := 8
+	green := color.RGBA{0, 200, 0, 255}
+	fill := color.RGBA{255, 0, 0, 255}
+	bounds := testBounds()
+
+	// Single source tile at (2, 2, 1).
+	reader := &mockPMTilesReader{
+		tiles: map[[3]int][]byte{
+			{2, 2, 1}: encodePNGTile(t, tileSize, green),
+		},
+		header: pmtiles.Header{MinZoom: 2, MaxZoom: 2,
+			MinLon: bounds[0], MinLat: bounds[1], MaxLon: bounds[2], MaxLat: bounds[3]},
+	}
+	writer := newMockTileWriter()
+	enc := testEncoder(t)
+
+	cfg := TransformConfig{
+		MinZoom:      0,
+		MaxZoom:      2,
+		TileSize:     tileSize,
+		Concurrency:  2,
+		Encoder:      enc,
+		SourceFormat: "png",
+		Resampling:   ResamplingBilinear,
+		Mode:         TransformRebuild,
+		FillColor:    &fill,
+		Bounds:       bounds,
+	}
+
+	stats, err := Transform(cfg, reader, writer)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	// Zoom 2: 4 positions in bounds, all should have tiles.
+	if n := writer.tileCountAtZoom(2); n != 4 {
+		t.Errorf("zoom 2: got %d tiles, want 4", n)
+	}
+	// Zoom 1: 2 positions in bounds.
+	if n := writer.tileCountAtZoom(1); n != 2 {
+		t.Errorf("zoom 1: got %d tiles, want 2", n)
+	}
+	// Zoom 0: 1 position.
+	if n := writer.tileCountAtZoom(0); n != 1 {
+		t.Errorf("zoom 0: got %d tiles, want 1", n)
+	}
+	// Total: 7 tiles.
+	if stats.TileCount != 7 {
+		t.Errorf("TileCount = %d, want 7", stats.TileCount)
+	}
+}
+
+// TestTransformRebuild_FillColor_FillTilesIdentical verifies that all fill
+// tiles at the same zoom level contain identical pre-encoded bytes.
+func TestTransformRebuild_FillColor_FillTilesIdentical(t *testing.T) {
+	tileSize := 8
+	green := color.RGBA{0, 200, 0, 255}
+	fill := color.RGBA{128, 128, 128, 255}
+	bounds := testBounds()
+
+	// Single source tile at (2, 2, 1); the other 3 positions are fill.
+	reader := &mockPMTilesReader{
+		tiles: map[[3]int][]byte{
+			{2, 2, 1}: encodePNGTile(t, tileSize, green),
+		},
+		header: pmtiles.Header{MinZoom: 2, MaxZoom: 2,
+			MinLon: bounds[0], MinLat: bounds[1], MaxLon: bounds[2], MaxLat: bounds[3]},
+	}
+	writer := newMockTileWriter()
+	enc := testEncoder(t)
+
+	cfg := TransformConfig{
+		MinZoom:      2,
+		MaxZoom:      2,
+		TileSize:     tileSize,
+		Concurrency:  1,
+		Encoder:      enc,
+		SourceFormat: "png",
+		Resampling:   ResamplingBilinear,
+		Mode:         TransformRebuild,
+		FillColor:    &fill,
+		Bounds:       bounds,
+	}
+
+	_, err := Transform(cfg, reader, writer)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	// The 3 fill tiles should have identical encoded data.
+	fillPositions := [][3]int{{2, 3, 1}, {2, 2, 2}, {2, 3, 2}}
+	var fillData []byte
+	for _, pos := range fillPositions {
+		data := writer.tiles[pos]
+		if data == nil {
+			t.Fatalf("missing fill tile at %v", pos)
+		}
+		if fillData == nil {
+			fillData = data
+		} else if !bytes.Equal(data, fillData) {
+			t.Errorf("fill tile at %v has different data than first fill tile", pos)
+		}
+	}
+
+	// The real tile should have different data than fill tiles.
+	realData := writer.tiles[[3]int{2, 2, 1}]
+	if realData == nil {
+		t.Fatal("missing real tile at (2,2,1)")
+	}
+	if bytes.Equal(realData, fillData) {
+		t.Error("real tile should have different data than fill tiles")
+	}
+}
+
+// TestTransformRebuild_FillColor_RealPositionPropagation verifies that real
+// positions propagate correctly to parent zoom levels: only parents with at
+// least one real child go through the downsample pipeline.
+func TestTransformRebuild_FillColor_RealPositionPropagation(t *testing.T) {
+	tileSize := 8
+	green := color.RGBA{0, 200, 0, 255}
+	fill := color.RGBA{255, 0, 0, 255}
+	bounds := testBounds()
+
+	// Source tile at (2, 2, 1): parent is (1, 1, 0).
+	reader := &mockPMTilesReader{
+		tiles: map[[3]int][]byte{
+			{2, 2, 1}: encodePNGTile(t, tileSize, green),
+		},
+		header: pmtiles.Header{MinZoom: 2, MaxZoom: 2,
+			MinLon: bounds[0], MinLat: bounds[1], MaxLon: bounds[2], MaxLat: bounds[3]},
+	}
+	writer := newMockTileWriter()
+	enc := testEncoder(t)
+
+	cfg := TransformConfig{
+		MinZoom:      1,
+		MaxZoom:      2,
+		TileSize:     tileSize,
+		Concurrency:  1,
+		Encoder:      enc,
+		SourceFormat: "png",
+		Resampling:   ResamplingNearest,
+		Mode:         TransformRebuild,
+		FillColor:    &fill,
+		Bounds:       bounds,
+	}
+
+	_, err := Transform(cfg, reader, writer)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	// (1,1,0) should be a real downsampled tile (not identical to fill).
+	// (1,1,1) should be a fill tile.
+	realParent := writer.tiles[[3]int{1, 1, 0}]
+	fillParent := writer.tiles[[3]int{1, 1, 1}]
+	if realParent == nil {
+		t.Fatal("missing real parent tile at (1,1,0)")
+	}
+	if fillParent == nil {
+		t.Fatal("missing fill parent tile at (1,1,1)")
+	}
+
+	// The real parent was downsampled from a mix of real+fill children,
+	// so it should differ from the pure fill tile.
+	if bytes.Equal(realParent, fillParent) {
+		t.Error("real parent at (1,1,0) should differ from fill parent at (1,1,1)")
+	}
+}
+
+// TestTransformRebuild_FillColor_Dense verifies that when all positions have
+// source data, no fill tiles are written.
+func TestTransformRebuild_FillColor_Dense(t *testing.T) {
+	tileSize := 8
+	fill := color.RGBA{255, 0, 0, 255}
+	bounds := testBounds()
+
+	// All 4 zoom-2 positions have source tiles (with distinct colors).
+	colors := [4]color.RGBA{
+		{100, 0, 0, 255},
+		{0, 100, 0, 255},
+		{0, 0, 100, 255},
+		{100, 100, 0, 255},
+	}
+	positions := [4][3]int{{2, 2, 1}, {2, 3, 1}, {2, 2, 2}, {2, 3, 2}}
+	tiles := make(map[[3]int][]byte)
+	for i, pos := range positions {
+		tiles[pos] = encodePNGTile(t, tileSize, colors[i])
+	}
+
+	reader := &mockPMTilesReader{
+		tiles:  tiles,
+		header: pmtiles.Header{MinZoom: 2, MaxZoom: 2, MinLon: bounds[0], MinLat: bounds[1], MaxLon: bounds[2], MaxLat: bounds[3]},
+	}
+	writer := newMockTileWriter()
+	enc := testEncoder(t)
+
+	cfg := TransformConfig{
+		MinZoom:      2,
+		MaxZoom:      2,
+		TileSize:     tileSize,
+		Concurrency:  2,
+		Encoder:      enc,
+		SourceFormat: "png",
+		Resampling:   ResamplingBilinear,
+		Mode:         TransformRebuild,
+		FillColor:    &fill,
+		Bounds:       bounds,
+	}
+
+	stats, err := Transform(cfg, reader, writer)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	if n := writer.tileCountAtZoom(2); n != 4 {
+		t.Errorf("zoom 2: got %d tiles, want 4", n)
+	}
+	if stats.TileCount != 4 {
+		t.Errorf("TileCount = %d, want 4", stats.TileCount)
+	}
+
+	// All tiles should be distinct (no pre-encoded fill reuse).
+	seen := make(map[string]bool)
+	for _, pos := range positions {
+		data := writer.tiles[pos]
+		if data == nil {
+			t.Errorf("missing tile at %v", pos)
+			continue
+		}
+		seen[string(data)] = true
+	}
+	if len(seen) != 4 {
+		t.Errorf("expected 4 distinct tile contents, got %d", len(seen))
+	}
+}
+
+// TestTransformRebuild_NoFill verifies that without fill-color, only source
+// tiles and their downsampled parents are produced (regression test).
+func TestTransformRebuild_NoFill(t *testing.T) {
+	tileSize := 8
+	green := color.RGBA{0, 200, 0, 255}
+	bounds := testBounds()
+
+	reader := &mockPMTilesReader{
+		tiles: map[[3]int][]byte{
+			{2, 2, 1}: encodePNGTile(t, tileSize, green),
+		},
+		header: pmtiles.Header{MinZoom: 2, MaxZoom: 2,
+			MinLon: bounds[0], MinLat: bounds[1], MaxLon: bounds[2], MaxLat: bounds[3]},
+	}
+	writer := newMockTileWriter()
+	enc := testEncoder(t)
+
+	cfg := TransformConfig{
+		MinZoom:      0,
+		MaxZoom:      2,
+		TileSize:     tileSize,
+		Concurrency:  1,
+		Encoder:      enc,
+		SourceFormat: "png",
+		Resampling:   ResamplingBilinear,
+		Mode:         TransformRebuild,
+		FillColor:    nil, // no fill
+		Bounds:       bounds,
+	}
+
+	stats, err := Transform(cfg, reader, writer)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	// Without fill, only the source tile is at max zoom.
+	if n := writer.tileCountAtZoom(2); n != 1 {
+		t.Errorf("zoom 2: got %d tiles, want 1", n)
+	}
+	// Lower zooms get downsampled parents (partial coverage).
+	if n := writer.tileCountAtZoom(1); n != 1 {
+		t.Errorf("zoom 1: got %d tiles, want 1", n)
+	}
+	if n := writer.tileCountAtZoom(0); n != 1 {
+		t.Errorf("zoom 0: got %d tiles, want 1", n)
+	}
+	if stats.TileCount != 3 {
+		t.Errorf("TileCount = %d, want 3", stats.TileCount)
+	}
+}
+
+// TestTransformRebuild_FillColor_StatsConsistency verifies that Stats counters
+// are consistent: fill tiles are counted as uniform.
+func TestTransformRebuild_FillColor_StatsConsistency(t *testing.T) {
+	tileSize := 8
+	green := color.RGBA{0, 200, 0, 255}
+	fill := color.RGBA{255, 0, 0, 255}
+	bounds := testBounds()
+
+	reader := &mockPMTilesReader{
+		tiles: map[[3]int][]byte{
+			{2, 2, 1}: encodePNGTile(t, tileSize, green),
+		},
+		header: pmtiles.Header{MinZoom: 2, MaxZoom: 2,
+			MinLon: bounds[0], MinLat: bounds[1], MaxLon: bounds[2], MaxLat: bounds[3]},
+	}
+	writer := newMockTileWriter()
+	enc := testEncoder(t)
+
+	cfg := TransformConfig{
+		MinZoom:      0,
+		MaxZoom:      2,
+		TileSize:     tileSize,
+		Concurrency:  1,
+		Encoder:      enc,
+		SourceFormat: "png",
+		Resampling:   ResamplingNearest,
+		Mode:         TransformRebuild,
+		FillColor:    &fill,
+		Bounds:       bounds,
+	}
+
+	stats, err := Transform(cfg, reader, writer)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	// Fill tiles should be counted as uniform.
+	// Zoom 2: 3 fill (uniform) + 1 real (uniform since solid green).
+	// Zoom 1: 1 fill (uniform) + 1 real (downsampled, likely uniform or mixed).
+	// Zoom 0: 1 real.
+	if stats.UniformTiles == 0 {
+		t.Error("expected some uniform tiles (fill tiles)")
+	}
+	// At minimum, 4 fill tiles: 3 at z2 + 1 at z1.
+	if stats.UniformTiles < 4 {
+		t.Errorf("UniformTiles = %d, want >= 4 (at least the fill tiles)", stats.UniformTiles)
+	}
+	if stats.TotalBytes <= 0 {
+		t.Error("expected positive TotalBytes")
+	}
+	if stats.EmptyTiles != 0 {
+		t.Errorf("EmptyTiles = %d, want 0 (fill should cover all positions)", stats.EmptyTiles)
+	}
+}


### PR DESCRIPTION
### Summary

- Sparse fill optimization: pmtransform --rebuild --fill-color now tracks which tile positions contain real (non-fill) data and propagates upward through zoom levels. Only real positions go through the expensive downsample/encode/store pipeline; all-fill positions get pre-encoded bytes written directly, skipping DiskTileStore overhead entirely.
- Pre-encoded fill tile reuse: The fill tile is encoded once before the zoom loop. All fill positions reuse the same bytes, eliminating redundant encoder calls (previously one per empty position per zoom level).
- Shared immutable TileData: A single fillTileShared instance replaces per-position newTileDataUniform allocations for nil-child substitution in the downsample path.

For a dataset with 1K source tiles covering 1M positions at zoom 14, this eliminates ~999K redundant encode calls, ~999K DiskTileStore entries (128 bytes overhead each), and the cascade through every lower zoom level.

### Test plan

- [x]  6 new unit tests in internal/tile/transform_test.go covering sparse fill, fill tile identity, real position propagation, dense fill, no-fill passthrough, and stats consistency
- [x]  2 new integration tests in integration/synthetic_test.go exercising rebuild + fill-color with both small and large extents
- [x]  make test-race passes (all existing + new tests)