### PR TITLE
Scan directories recursively for TIFF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 
 ### Examples
 
-Convert a directory of GeoTIFFs with auto zoom detection:
+Convert a directory of GeoTIFFs with auto zoom detection (scans subfolders recursively):
 
 ```bash
 ./geotiff2pmtiles --verbose integration/testdata/swissimage/ output.pmtiles

--- a/changes/2026-02-28-recursive-directory-scan.md
+++ b/changes/2026-02-28-recursive-directory-scan.md
@@ -1,0 +1,17 @@
+# Recursive directory scanning for TIFF files
+
+## What changed
+`collectTIFFs()` in `cmd/geotiff2pmtiles/main.go` now walks directories
+recursively using `filepath.WalkDir` instead of only listing immediate
+directory entries with `os.ReadDir`. TIFF files in subfolders are now
+discovered automatically.
+
+## Why
+Users organizing large datasets into subdirectories (e.g., by region or
+acquisition date) previously had to list each subfolder individually or
+flatten the structure. Recursive scanning lets a single top-level directory
+path find all `.tif`/`.tiff` files regardless of nesting depth.
+
+## Files modified
+- `cmd/geotiff2pmtiles/main.go` — `collectTIFFs()`: `os.ReadDir` → `filepath.WalkDir`; added `io/fs` import; updated CLI help text
+- `README.md` — noted recursive scanning in directory example

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"image/color"
+	"io/fs"
 	"log"
 	"math"
 	"os"
@@ -79,7 +80,8 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>\n\n")
-		fmt.Fprintf(os.Stderr, "Convert GeoTIFF/COG files to a PMTiles v3 archive.\n\n")
+		fmt.Fprintf(os.Stderr, "Convert GeoTIFF/COG files to a PMTiles v3 archive.\n")
+		fmt.Fprintf(os.Stderr, "Directories are scanned recursively for .tif/.tiff files.\n\n")
 		fmt.Fprintf(os.Stderr, "Flags:\n")
 		flag.PrintDefaults()
 	}
@@ -391,6 +393,7 @@ func main() {
 }
 
 // collectTIFFs resolves input paths to a list of .tif files.
+// Directories are walked recursively to find TIFF files in subfolders.
 func collectTIFFs(paths []string) ([]string, error) {
 	var result []string
 	for _, p := range paths {
@@ -399,14 +402,17 @@ func collectTIFFs(paths []string) ([]string, error) {
 			return nil, fmt.Errorf("stat %s: %w", p, err)
 		}
 		if info.IsDir() {
-			entries, err := os.ReadDir(p)
-			if err != nil {
-				return nil, fmt.Errorf("readdir %s: %w", p, err)
-			}
-			for _, e := range entries {
-				if !e.IsDir() && isTIFF(e.Name()) {
-					result = append(result, filepath.Join(p, e.Name()))
+			err := filepath.WalkDir(p, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
 				}
+				if !d.IsDir() && isTIFF(d.Name()) {
+					result = append(result, path)
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, fmt.Errorf("walk %s: %w", p, err)
 			}
 		} else if isTIFF(p) {
 			result = append(result, p)


### PR DESCRIPTION
Previously collectTIFFs only listed immediate directory entries. Now uses filepath.WalkDir to discover .tif/.tiff files in subfolders, so users can pass a top-level directory containing nested subdirectories.