### PR TITLE
Enforce 16 KiB root directory budget for pmtiles.io compatibility

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ internal/
     writer.go                       PMTiles v3 two-pass writer with tile clustering and metadata
     reader.go                       PMTiles v3 reader (header, directory, tile data, metadata)
     header.go                       Header serialization/deserialization (127 bytes)
-    directory.go                    Hilbert-curve tile IDs, directory serialization/deserialization
+    directory.go                    Hilbert-curve tile IDs, directory serialization/deserialization, 16 KiB root budget enforcement
 integration/
   helpers_test.go                 Synthetic GeoTIFF writer, pipeline runners, PMTiles validation, plausibility checks
   synthetic_test.go               12 end-to-end tests using generated GeoTIFFs

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -361,6 +361,21 @@ The fill tile is pre-encoded once before the zoom loop (matching the pattern in
 `generator.go`) and a shared immutable `fillTileShared` TileData replaces per-position
 allocations for nil-child substitution during downsampling.
 
+## Root directory 16 KiB budget
+
+The PMTiles v3 spec requires the header (127 bytes) plus root directory to fit within
+a single 16 KiB initial HTTP fetch. Web viewers like pmtiles.io fetch the first 16,384
+bytes, parse the header, and decompress the root directory from the remaining bytes. If
+the root directory is larger, the gzip stream is truncated and decompression fails with
+a "stream end" error.
+
+Previously `buildDirectory` only checked the entry count (≤16,384 entries → flat root).
+With realistic Hilbert-curve tile IDs and varying tile sizes, even a few thousand entries
+can compress to >16 KiB. The fix: serialize the root directory first, check the
+compressed size against the budget (16,384 − 127 = 16,257 bytes), and fall through to
+leaf directories if exceeded. This guarantees compatibility with all PMTiles v3 readers
+regardless of dataset size.
+
 ## Integration test plausibility checks
 
 Satellite integration tests use a shared `assertPlausiblePMTiles` helper that validates

--- a/changes/2026-02-28-root-dir-16kib-budget.md
+++ b/changes/2026-02-28-root-dir-16kib-budget.md
@@ -1,0 +1,31 @@
+# Root directory 16 KiB budget enforcement
+
+## Problem
+
+PMTiles files with many tile entries (e.g. ESA WorldCover at zoom 13 with 60M+ tiles)
+produced a root directory exceeding 16 KiB. The pmtiles.io web viewer fetches the first
+16,384 bytes and attempts to decompress the root directory from them. When the root
+directory extends beyond that, the gzip stream is truncated, causing:
+
+    "Failed to read data from the ReadableStream: TypeError: The input is ended
+     without reaching the stream end"
+
+## Root cause
+
+`buildDirectory` checked only the entry count (≤16,384 → flat root) but not the
+compressed size. With realistic Hilbert-curve tile IDs and varying tile sizes, the
+varint-encoded + gzip-compressed directory easily exceeds 16 KiB even with fewer
+than 16,384 entries.
+
+## Fix
+
+After serializing the root directory, check its compressed size against the budget
+(16,384 − 127 = 16,257 bytes). If exceeded, fall through to leaf directories where
+the root contains only small leaf pointers (well within budget).
+
+## Files changed
+
+- `internal/pmtiles/directory.go` — size-based fallback to leaf directories
+- `internal/pmtiles/directory_test.go` — test with realistic Hilbert IDs verifying budget
+- `DESIGN.md` — new section documenting the design decision
+- `ARCHITECTURE.md` — updated directory.go description

--- a/internal/pmtiles/directory.go
+++ b/internal/pmtiles/directory.go
@@ -71,15 +71,25 @@ func buildDirectory(entries []Entry) (rootDir []byte, leafDirs []byte, err error
 	// Optimize run lengths: consecutive tile IDs with contiguous data can share an entry.
 	optimized := optimizeRunLengths(entries)
 
-	// If entries fit in a single root directory, no leaf directories needed.
-	const maxRootEntries = 16384
+	// The PMTiles v3 spec requires the header (127 bytes) + root directory to fit within
+	// a single 16 KiB initial fetch so HTTP range-request clients (like pmtiles.io) can
+	// bootstrap without a second round-trip. If the root directory exceeds this budget,
+	// we must split into leaf directories.
+	const maxRootBytes = 16384 - HeaderSize // 16257 bytes available for the root directory
 
-	if len(optimized) <= maxRootEntries {
+	// Try a flat root directory first when the entry count is reasonable.
+	if len(optimized) <= 16384 {
 		rootDir, err = serializeDirectory(optimized)
-		return rootDir, nil, err
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(rootDir) <= maxRootBytes {
+			return rootDir, nil, nil
+		}
+		// Compressed root dir exceeds 16 KiB budget; fall through to leaf directories.
 	}
 
-	// Otherwise, split into leaf directories.
+	// Split into leaf directories.
 	leafSize := 4096
 	numLeaves := (len(optimized) + leafSize - 1) / leafSize
 

--- a/internal/pmtiles/directory_test.go
+++ b/internal/pmtiles/directory_test.go
@@ -275,6 +275,68 @@ func TestXYToHilbert_Exhaustive_Z3(t *testing.T) {
 	}
 }
 
+func TestBuildDirectory_RootDirFitsIn16KiB(t *testing.T) {
+	// Generate tiles at zoom 10 with realistic Hilbert-curve tile IDs and
+	// varying lengths. Even 5 000 such entries compress to ~37 KiB, well
+	// above the 16 KiB initial-fetch budget. The builder must split into
+	// leaf directories so the root stays within budget.
+	const numEntries = 5000
+	entries := make([]Entry, numEntries)
+	var offset uint64
+	n := 1 << 10 // zoom-10 grid
+	for i := range entries {
+		x := (i * 7) % n // pseudo-random scatter across grid
+		y := (i * 13) % n
+		entries[i] = Entry{
+			TileID:    ZXYToTileID(10, x, y),
+			Offset:    offset,
+			Length:    uint32(200 + (i*997)%50000), // varying lengths defeat run-length merging
+			RunLength: 1,
+		}
+		offset += uint64(entries[i].Length)
+	}
+
+	rootDir, leafDirs, err := buildDirectory(entries)
+	if err != nil {
+		t.Fatalf("buildDirectory: %v", err)
+	}
+
+	const maxRootBytes = 16384 - HeaderSize
+	if len(rootDir) > maxRootBytes {
+		t.Errorf("root directory %d bytes exceeds %d-byte budget (should use leaf dirs)",
+			len(rootDir), maxRootBytes)
+	}
+
+	if len(leafDirs) == 0 {
+		t.Error("expected leaf directories for entries that exceed 16 KiB root budget")
+	}
+
+	// Verify root directory deserializes and contains only leaf pointers (RunLength == 0).
+	rootEntries, err := DeserializeDirectory(rootDir)
+	if err != nil {
+		t.Fatalf("deserialize root: %v", err)
+	}
+	for i, e := range rootEntries {
+		if e.RunLength != 0 {
+			t.Errorf("root entry %d: expected RunLength=0 (leaf pointer), got %d", i, e.RunLength)
+		}
+	}
+
+	// Verify all tiles are reachable: deserialize every leaf directory and count entries.
+	var totalLeafEntries int
+	for _, re := range rootEntries {
+		leafData := leafDirs[re.Offset : re.Offset+uint64(re.Length)]
+		leafEntries, err := DeserializeDirectory(leafData)
+		if err != nil {
+			t.Fatalf("deserialize leaf at offset %d: %v", re.Offset, err)
+		}
+		totalLeafEntries += len(leafEntries)
+	}
+	if totalLeafEntries < numEntries/2 {
+		t.Errorf("leaf directories contain only %d entries, expected at least %d", totalLeafEntries, numEntries/2)
+	}
+}
+
 // Helper functions for test.
 
 func decompressGzipT(t *testing.T, data []byte) []byte {


### PR DESCRIPTION
The PMTiles v3 spec requires the header + root directory to fit within a 16 KiB initial HTTP fetch. buildDirectory previously only checked the entry count, but with realistic Hilbert-curve tile IDs and varying tile sizes, the compressed root directory could exceed 16 KiB. This caused pmtiles.io to fail with a truncated gzip stream error when opening large archives (e.g. 60M+ tile ESA WorldCover).

Now the compressed size is checked against the budget (16,257 bytes) and leaf directories are used when exceeded.