### PR TITLE
Honor nodata on JPEG tiles and support planar-separate COGs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,8 @@ skipping DiskTileStore overhead entirely.
 - Continuous disk spilling via dedicated I/O goroutine with configurable memory backpressure (auto ~90% of RAM)
 - Uniform tiles (single color) stored as 4 bytes, never spilled to disk
 - `sync.Pool` for `*image.RGBA` buffers: render, downsample, and decode paths reuse 256 KB buffers instead of allocating/GC'ing per tile
-- Nodata pixels (all bands equal to GDAL_NODATA tag value) decoded as transparent (alpha=0) for single-band and multi-band/16-bit data; stored in `BandConfig.HasNodata`/`Nodata`, auto-detected from GeoTIFF, overridable with `--nodata`
+- Nodata pixels (all bands within `BandConfig.NodataTolerance` of `BandConfig.Nodata`) decoded as transparent (alpha=0). Honoured by the raw, Deflate, LZW, and JPEG decode paths; planar-separate JPEG applies it after the per-plane merge. Auto-detected from the GDAL_NODATA tag; overridable with `--nodata` and `--nodata-tolerance` (use 4–8 for lossy-JPEG borders). When `--nodata` is set and `--format` is left at its default, the CLI switches output from `jpeg` → `webp` so transparency survives the encode step.
+- Planar-separate (`PlanarConfiguration=2`) JPEG COGs: each band is decoded from its own per-plane JPEG tile and merged into RGBA at read time. Plane 0→R, 1→G, 2→B, 3→A; missing channels are duplicated from plane 0 (grayscale).
 - Source fallthrough on nodata: transparent (alpha=0) samples are skipped and the next source is tried, preventing holes in one source from blocking valid data in another
 - PMTiles writer uses temp file for tile data (only directory entries in memory)
 - Pyramid downsampling avoids redundant source reads for lower zoom levels

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -102,9 +102,36 @@ gray+alpha also overrides the alpha channel.
 `BandConfig.HasNodata`/`BandConfig.Nodata`. `DetectPreset()` automatically populates
 these from the GDAL_NODATA tag (integer in [0,65535]) so the preset is self-contained.
 The `--nodata` CLI flag overrides the auto-detected value. In the pixel loop, all `spp`
-file bands are compared to the raw nodata value before rescaling; if all match, the pixel
-is emitted as (0,0,0,0). Only applied when there is no dedicated alpha band
-(`effectiveAlpha < 0`), since an alpha band already encodes transparency directly.
+file bands are compared to the raw nodata value before rescaling; if all are within
+`BandConfig.NodataTolerance` of the nodata value, the pixel is emitted as (0,0,0,0).
+Only applied when there is no dedicated alpha band (`effectiveAlpha < 0`), since an
+alpha band already encodes transparency directly.
+
+**Tolerance for lossy-JPEG borders**: COGs scanned from historic imagery often have
+black-padded borders that are *intended* as nodata but, because the file is JPEG-
+compressed, decode as 1..8 rather than strict 0. `BandConfig.NodataTolerance` (CLI:
+`--nodata-tolerance`) widens the match to `|sample - nodata| ≤ tolerance` so those
+borders disappear cleanly. Default 0 keeps exact-match semantics.
+
+**JPEG decode path**: previously returned the JPEG-decoded image untouched, silently
+ignoring `BandConfig.HasNodata`. `decodeJPEGTile` now materialises the image as RGBA
+and zeroes alpha+RGB for nodata pixels when `HasNodata` is set; without nodata it
+still returns the raw `*image.YCbCr`/`*image.Gray` to preserve the fast sampling path.
+
+**Planar-separate JPEG** (`PlanarConfiguration=2`): each band lives in its own
+per-plane JPEG tile, with offsets laid out plane-major. `ReadTile` dispatches to
+`decodePlanarSeparateJPEG`, which decodes each plane (using `grayBytes` to extract
+the single channel from `*image.Gray` or single-band `*image.YCbCr`) and merges into
+RGBA: plane 0→R, 1→G, 2→B, 3→A. Missing channels are duplicated from plane 0 so
+grayscale planar-separate files render correctly. Nodata is applied after the merge.
+Uncompressed and Deflate/LZW planar-separate are rare in practice and currently
+return an explicit "not supported" error rather than silently decoding wrong data
+(the previous behaviour silently returned plane 0 as R=G=B).
+
+**Output-format auto-switch**: when `--nodata` is active, JPEG output cannot carry
+alpha, so transparent pixels would be baked back to black in the encoded tile. If
+the user did not explicitly set `--format`, the CLI switches the default `jpeg` →
+`webp`. If the user explicitly chose `--format=jpeg`, it warns and proceeds.
 
 All downstream code (bilinear/Lanczos/bicubic resampling, mode downsampling,
 `sampleFromTileSources`) excludes alpha=0 pixels from interpolation and voting, and

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>
 | `--alpha-band`  | `auto`        | Alpha band: `auto` (band 4 for 8-bit spp>=4), `-1` (none), or 1-indexed band |
 | `--rescale`     | `auto`        | Rescale mode: `auto`, `linear`, `log`, `none` (auto requires `--rescale-range` for 16-bit) |
 | `--rescale-range` |             | Input value range `min,max` for rescaling (required for 16-bit data) |
-| `--nodata`      |               | Nodata value: pixels with all bands equal to this integer are transparent (auto-detected from GeoTIFF if not set) |
+| `--nodata`      |               | Nodata value: pixels with all bands equal to this integer are transparent (auto-detected from GeoTIFF if not set). When set without `--format`, output auto-switches from `jpeg` to `webp` so transparency is preserved. |
+| `--nodata-tolerance` | `0`      | Per-band tolerance for `--nodata` matching. Use 4–8 for borders that come from lossy JPEG sources, where the strict nodata value is smeared by compression. |
 | `--verbose`     | `false`       | Verbose progress output                            |
 | `--version`     |               | Print version and exit                             |
 | `--cpuprofile`  |               | Write CPU profile to file                          |
@@ -154,6 +155,14 @@ Fill transparent/nodata areas with a solid color (e.g. black):
 ```bash
 ./geotiff2pmtiles --fill-color "0,0,0,255" --format png \
   input/ output.pmtiles
+```
+
+Historic JPEG-compressed scan with a black border (output auto-switches to WebP for transparency):
+
+```bash
+./geotiff2pmtiles --nodata 0 --nodata-tolerance 8 \
+  scan.tif output.pmtiles
+# Nodata is active; switching output format jpeg → webp so transparency is preserved.
 ```
 
 Elevation data (auto-detects float GeoTIFF and selects Terrarium encoding):

--- a/changes/2026-05-12-19-33-jpeg-nodata-and-planar-separate.md
+++ b/changes/2026-05-12-19-33-jpeg-nodata-and-planar-separate.md
@@ -1,0 +1,113 @@
+# JPEG nodata, tolerance, output-format auto-switch, and planar-separate JPEG
+
+## Problem
+
+Reported while converting `Katahdin1952_rgb_jpg.tif` — a JPEG-compressed, 3-band,
+`PlanarConfiguration=2` BigTIFF carrying a grayscale scan padded with black at
+the scanned-area edges:
+
+```
+./geotiff2pmtiles --verbose --nodata 0 Katahdin1952_rgb_jpg.tif kt.pmtiles
+...
+Band config: bands 1,2,3, nodata 0   ← logged, but no pixels were ever masked
+```
+
+The black border was never detected as nodata. Investigation surfaced four
+distinct issues:
+
+1. `decodeJPEGTile` in `internal/cog/reader.go` returned the JPEG-decoded image
+   directly and never consulted `BandConfig.HasNodata`/`Nodata`. Nodata worked
+   on raw / Deflate / LZW tiles but was silently dropped on JPEG.
+2. Even where nodata was honoured, the comparison was strict equality. Borders
+   in lossy-JPEG sources are smeared by quantisation (typical values 1..8 for a
+   pure-black border at quality 50), so an exact-match `value == 0` matched
+   nothing useful.
+3. Output format defaulted to `jpeg`, which cannot carry alpha. Even with the
+   other two issues fixed, transparent pixels would be re-encoded as black.
+4. The reader parsed `PlanarConfiguration` but never used it. With a planar-
+   separate file, only the first plane's tile index was decoded. The Katahdin
+   file rendered "correctly" only because all three bands held identical
+   grayscale data — a genuinely-colour planar-separate JPEG COG would have been
+   rendered as red-only.
+
+## Changes
+
+### `internal/cog/reader.go`
+
+- `BandConfig` gains `NodataTolerance float64`. A sample matches nodata when
+  `|sample - Nodata| ≤ NodataTolerance`. Default 0 keeps the exact-match
+  behaviour.
+- `decodeRawTile`'s general-path nodata loop now uses the tolerance.
+- `decodeJPEGTile` was split: `decodeJPEGBytes` produces the raw decoded image
+  (preserving the YCbCr/Gray fast path when no nodata is configured), and
+  `decodeJPEGTile` materialises RGBA + applies a nodata mask only when
+  `BandConfig.HasNodata` is set.
+- `decodePlanarSeparateJPEG` decodes each per-plane JPEG tile (offsets are
+  plane-major) and merges into RGBA. Plane 0→R, 1→G, 2→B, 3→A; channels beyond
+  the available plane count fall back to plane 0 so grayscale planar-separate
+  files render correctly. Nodata is applied after the merge.
+- `ReadTile` dispatches `PlanarConfig=2 && SamplesPerPixel>1` to the new
+  function. Non-JPEG planar-separate (uncompressed, Deflate, LZW) returns an
+  explicit error rather than silently returning plane 0.
+
+### `cmd/geotiff2pmtiles/main.go`
+
+- New `--nodata-tolerance` flag.
+- When `--nodata` is set and `--format` was left at its default, the CLI
+  switches output `jpeg` → `webp` so transparency survives encoding. When the
+  user explicitly chose `--format=jpeg`, the CLI warns instead of switching.
+- `isFlagSet(name)` helper distinguishes default values from explicit user
+  input.
+
+### Tests (`internal/cog/jpeg_test.go`)
+
+- `TestDecodeJPEGTileNodataExact` — a synthesised single-band JPEG with a
+  half-black/half-gray layout becomes half-transparent/half-opaque.
+- `TestDecodeJPEGTileNoNodataPassthrough` — verifies the YCbCr/Gray fast path
+  is preserved when no nodata is configured (return type is *not* `*image.RGBA`).
+- `TestPlanarSeparateJPEG` — three solid-colour grayscale JPEG planes merge to
+  the expected RGBA pixel within JPEG's quality tolerance.
+- `TestPlanarSeparateRawErrors` — uncompressed planar-separate returns a clear
+  error instead of returning wrong pixels.
+- `TestNodataTolerance` — `(3,2,4)` is masked when tolerance is 5.
+
+### Docs
+
+- `README.md`: flag table entries for `--nodata` (auto-switch behaviour) and
+  `--nodata-tolerance`; new example for the lossy-border use case.
+- `ARCHITECTURE.md`: updated nodata bullet and added a planar-separate bullet.
+- `DESIGN.md`: extended the nodata section with the tolerance rationale, JPEG
+  decode path, planar-separate decoding, and the output-format auto-switch.
+
+## Verification
+
+```
+$ ./dist/geotiff2pmtiles --verbose --nodata 0 --nodata-tolerance 8 \
+    Katahdin1952_rgb_jpg.tif /tmp/kt.pmtiles
+Nodata is active; switching output format jpeg → webp ...
+Band config: bands 1,2,3, nodata 0 (tol 8)
+Zoom 15: completed (2067 tiles so far, 1493 gray, 366 uniform, 0 empty)
+```
+
+`366 uniform` tiles at z15 are the all-transparent border tiles being compacted
+away — they were `0 uniform` before the fix.
+
+```
+$ go test ./...
+ok      .../integration
+ok      .../internal/cog
+ok      .../internal/coord
+ok      .../internal/encode
+ok      .../internal/pmtiles
+ok      .../internal/tile
+```
+
+## Out of scope
+
+- Raw/Deflate/LZW planar-separate COGs return an explicit error rather than a
+  full decode. The TIFF spec allows it, but it's rare in practice and would
+  need a per-plane raw decode path. Filed as a follow-up.
+- The legacy single-band nodata path (`spp ≤ 2 && default BandConfig`) reads
+  nodata from the IFD GDAL_NODATA tag only and ignores `BandConfig.HasNodata`.
+  This was the existing behaviour and is unchanged here; the general path now
+  handles the case via tolerance, and the legacy fast path remains.

--- a/cmd/geotiff2pmtiles/main.go
+++ b/cmd/geotiff2pmtiles/main.go
@@ -52,6 +52,7 @@ func main() {
 		rescaleStr      string
 		rescaleRange    string
 		nodataStr       string
+		nodataTolStr    string
 		resamplingGamma float64
 	)
 
@@ -77,6 +78,7 @@ func main() {
 	flag.StringVar(&rescaleStr, "rescale", "auto", "Rescale mode: auto, log, linear, none (auto: requires --rescale-range for 16-bit)")
 	flag.StringVar(&rescaleRange, "rescale-range", "", "Input value range for rescaling: min,max (required for 16-bit data)")
 	flag.StringVar(&nodataStr, "nodata", "", "Nodata value: pixels with all bands equal to this integer are transparent (auto-detected from GeoTIFF if not set)")
+	flag.StringVar(&nodataTolStr, "nodata-tolerance", "", "Per-band tolerance applied to --nodata matching (default 0 = exact match). Useful for lossy-JPEG borders where strict 0 is smeared to 1..5; try 4–8.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: geotiff2pmtiles [flags] <input-dir-or-files...> <output.pmtiles>\n\n")
@@ -239,6 +241,35 @@ func main() {
 			if v, err := strconv.ParseFloat(strings.TrimSpace(nd), 64); err == nil && v >= 0 && v <= 65535 && v == math.Floor(v) {
 				bandCfg.HasNodata = true
 				bandCfg.Nodata = v
+			}
+		}
+	}
+
+	// --nodata-tolerance: only meaningful when nodata is active.
+	if nodataTolStr != "" {
+		v, err := strconv.ParseFloat(strings.TrimSpace(nodataTolStr), 64)
+		if err != nil || v < 0 || v > 65535 || v != math.Floor(v) {
+			log.Fatalf("--nodata-tolerance: must be a non-negative integer ≤ 65535, got %q", nodataTolStr)
+		}
+		if !bandCfg.HasNodata {
+			log.Printf("WARNING: --nodata-tolerance set without --nodata; ignored")
+		} else {
+			bandCfg.NodataTolerance = v
+		}
+	}
+
+	// If nodata is active but the output format can't carry transparency,
+	// switch to WebP automatically (when the user didn't pick --format),
+	// or warn if they explicitly chose jpeg.
+	if bandCfg.HasNodata && format == "jpeg" {
+		if isFlagSet("format") {
+			log.Printf("WARNING: --nodata is set but --format=jpeg cannot carry transparency; nodata pixels will be encoded as black. Use --format=webp or --format=png for true transparency.")
+		} else {
+			log.Printf("Nodata is active; switching output format jpeg → webp so transparency is preserved (override with --format=jpeg).")
+			format = "webp"
+			enc, err = encode.NewEncoder(format, quality)
+			if err != nil {
+				log.Fatalf("Encoder: %v", err)
 			}
 		}
 	}
@@ -505,6 +536,18 @@ func buildDescription(sources []*cog.Reader, mergedBounds cog.Bounds, gaps []cog
 	}
 
 	return b.String()
+}
+
+// isFlagSet reports whether a flag was explicitly passed on the command line
+// (as opposed to taking its default value).
+func isFlagSet(name string) bool {
+	set := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	return set
 }
 
 // parseColor parses an RGBA color from "R,G,B,A" or "#RRGGBBAA" format.

--- a/internal/cog/jpeg_test.go
+++ b/internal/cog/jpeg_test.go
@@ -1,0 +1,216 @@
+package cog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/jpeg"
+	"testing"
+)
+
+// encodeJPEGGray encodes an in-memory gray image to a stand-alone JPEG byte
+// stream (no separate JPEGTables tag — full headers inline). Used by tests to
+// synthesise per-band JPEG tile blobs.
+func encodeJPEGGray(t *testing.T, pix []uint8, w, h int, quality int) []byte {
+	t.Helper()
+	g := image.NewGray(image.Rect(0, 0, w, h))
+	copy(g.Pix, pix) // assumes Stride == w (true for our tiny tiles)
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, g, &jpeg.Options{Quality: quality}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestDecodeJPEGTileNodataExact: a single-band JPEG with nodata=0 (exact match,
+// high quality) — boundary black pixels become alpha=0.
+func TestDecodeJPEGTileNodataExact(t *testing.T) {
+	w, h := 16, 16
+	// Half black, half mid-gray.
+	pix := make([]uint8, w*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			if x < w/2 {
+				pix[y*w+x] = 0
+			} else {
+				pix[y*w+x] = 200
+			}
+		}
+	}
+	stream := encodeJPEGGray(t, pix, w, h, 95)
+
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: 1,
+		BitsPerSample:   []uint16{8},
+		Compression:     7,
+	}
+	r := &Reader{
+		bo:      binary.LittleEndian,
+		ifds:    []IFD{*ifd},
+		bandCfg: BandConfig{HasNodata: true, Nodata: 0, NodataTolerance: 4},
+	}
+
+	img, err := r.decodeJPEGTile(ifd, stream)
+	if err != nil {
+		t.Fatalf("decodeJPEGTile: %v", err)
+	}
+	rgba, ok := img.(*image.RGBA)
+	if !ok {
+		t.Fatalf("expected *image.RGBA, got %T", img)
+	}
+
+	// Left half should be transparent; right half opaque.
+	leftA := rgba.Pix[rgba.PixOffset(0, h/2)+3]
+	rightA := rgba.Pix[rgba.PixOffset(w-1, h/2)+3]
+	if leftA != 0 {
+		t.Errorf("left (nodata) alpha = %d, want 0", leftA)
+	}
+	if rightA != 255 {
+		t.Errorf("right (data) alpha = %d, want 255", rightA)
+	}
+}
+
+// TestDecodeJPEGTileNoNodataPassthrough: without nodata, the JPEG path returns
+// the raw decoded image (not RGBA), preserving the YCbCr/Gray fast path used
+// by downstream sampling.
+func TestDecodeJPEGTileNoNodataPassthrough(t *testing.T) {
+	w, h := 16, 16
+	pix := make([]uint8, w*h)
+	for i := range pix {
+		pix[i] = uint8(i % 256)
+	}
+	stream := encodeJPEGGray(t, pix, w, h, 95)
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: 1,
+		BitsPerSample:   []uint16{8},
+		Compression:     7,
+	}
+	r := &Reader{bo: binary.LittleEndian, ifds: []IFD{*ifd}}
+
+	img, err := r.decodeJPEGTile(ifd, stream)
+	if err != nil {
+		t.Fatalf("decodeJPEGTile: %v", err)
+	}
+	if _, isRGBA := img.(*image.RGBA); isRGBA {
+		t.Errorf("expected non-RGBA passthrough when nodata is off; got *image.RGBA")
+	}
+}
+
+// TestPlanarSeparateJPEG: three separately-encoded grayscale JPEG planes are
+// merged into RGBA with the natural plane→channel mapping.
+func TestPlanarSeparateJPEG(t *testing.T) {
+	w, h := 16, 16
+	// Plane 0: solid 100, plane 1: solid 150, plane 2: solid 200.
+	mk := func(v uint8) []byte {
+		buf := make([]uint8, w*h)
+		for i := range buf {
+			buf[i] = v
+		}
+		return encodeJPEGGray(t, buf, w, h, 95)
+	}
+	p0, p1, p2 := mk(100), mk(150), mk(200)
+
+	// Lay out the planes end-to-end in a single buffer.
+	combined := append(append(append([]byte{}, p0...), p1...), p2...)
+	offsets := []uint64{
+		0,
+		uint64(len(p0)),
+		uint64(len(p0) + len(p1)),
+	}
+	counts := []uint64{uint64(len(p0)), uint64(len(p1)), uint64(len(p2))}
+
+	ifd := &IFD{
+		Width:           uint32(w),
+		Height:          uint32(h),
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: 3,
+		BitsPerSample:   []uint16{8, 8, 8},
+		Compression:     7,
+		PlanarConfig:    2,
+		TileOffsets:     offsets,
+		TileByteCounts:  counts,
+	}
+	r := &Reader{bo: binary.LittleEndian, ifds: []IFD{*ifd}, data: combined}
+
+	img, err := r.ReadTile(0, 0, 0)
+	if err != nil {
+		t.Fatalf("ReadTile: %v", err)
+	}
+	rgba, ok := img.(*image.RGBA)
+	if !ok {
+		t.Fatalf("expected *image.RGBA, got %T", img)
+	}
+
+	// JPEG is lossy at solid colours but should be within a small delta.
+	i := rgba.PixOffset(w/2, h/2)
+	rr, gg, bb, aa := rgba.Pix[i], rgba.Pix[i+1], rgba.Pix[i+2], rgba.Pix[i+3]
+	near := func(got, want uint8) bool {
+		d := int(got) - int(want)
+		if d < 0 {
+			d = -d
+		}
+		return d <= 4
+	}
+	if !near(rr, 100) || !near(gg, 150) || !near(bb, 200) || aa != 255 {
+		t.Errorf("center pixel = (%d,%d,%d,%d), want ≈(100,150,200,255)", rr, gg, bb, aa)
+	}
+}
+
+// TestPlanarSeparateRawErrors: uncompressed PlanarConfig=2 isn't supported
+// yet; ReadTile should report it clearly rather than silently decoding wrong
+// pixels.
+func TestPlanarSeparateRawErrors(t *testing.T) {
+	w, h := 4, 4
+	ifd := &IFD{
+		Width:           uint32(w),
+		Height:          uint32(h),
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: 3,
+		BitsPerSample:   []uint16{8, 8, 8},
+		Compression:     1, // uncompressed
+		PlanarConfig:    2,
+		TileOffsets:     []uint64{0},
+		TileByteCounts:  []uint64{uint64(w * h)},
+	}
+	r := &Reader{bo: binary.LittleEndian, ifds: []IFD{*ifd}, data: make([]byte, w*h)}
+
+	if _, err := r.ReadTile(0, 0, 0); err == nil {
+		t.Fatal("expected error for uncompressed planar-separate, got nil")
+	}
+}
+
+// TestNodataTolerance: with tolerance=5, a near-zero value like 3 still
+// triggers transparency on the raw decode path.
+func TestNodataTolerance(t *testing.T) {
+	w, h, spp := 2, 1, 3
+	// pixel0 = (3,2,4) — near zero. pixel1 = (200,200,200) — data.
+	data := []byte{3, 2, 4, 200, 200, 200}
+	ifd := &IFD{
+		TileWidth:       uint32(w),
+		TileHeight:      uint32(h),
+		SamplesPerPixel: uint16(spp),
+		BitsPerSample:   []uint16{8, 8, 8},
+	}
+	r := &Reader{
+		bo:      binary.LittleEndian,
+		ifds:    []IFD{*ifd},
+		bandCfg: BandConfig{HasNodata: true, Nodata: 0, NodataTolerance: 5},
+	}
+	img, err := r.decodeRawTile(ifd, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rgba := img.(*image.RGBA)
+	if a := rgba.Pix[rgba.PixOffset(0, 0)+3]; a != 0 {
+		t.Errorf("pixel0 alpha = %d, want 0 (within tolerance)", a)
+	}
+	if a := rgba.Pix[rgba.PixOffset(1, 0)+3]; a != 255 {
+		t.Errorf("pixel1 alpha = %d, want 255", a)
+	}
+}

--- a/internal/cog/reader.go
+++ b/internal/cog/reader.go
@@ -36,6 +36,11 @@ type BandConfig struct {
 	RescaleMax float64     // Input value range maximum
 	HasNodata  bool        // if true, pixels with all bands == Nodata are decoded as transparent (alpha=0)
 	Nodata     float64     // raw (pre-rescale) nodata value; valid when HasNodata is true
+	// NodataTolerance widens the match: a sample is considered nodata when
+	// |sample - Nodata| <= NodataTolerance. Useful for lossy-JPEG borders where
+	// compression smears strict nodata values (e.g. boundary blacks of 1..5
+	// instead of exactly 0). 0 = exact match.
+	NodataTolerance float64
 }
 
 // String returns a human-readable summary of the band configuration.
@@ -57,6 +62,9 @@ func (cfg BandConfig) String() string {
 	}
 	if cfg.HasNodata {
 		fmt.Fprintf(&b, ", nodata %.0f", cfg.Nodata)
+		if cfg.NodataTolerance > 0 {
+			fmt.Fprintf(&b, " (tol %.0f)", cfg.NodataTolerance)
+		}
 	}
 	return b.String()
 }
@@ -582,6 +590,16 @@ func (r *Reader) ReadTile(level, col, row int) (image.Image, error) {
 		return r.decodeRawTile(ifd, data)
 	}
 
+	// Planar-separate layout: each band is stored in its own per-tile blob,
+	// with offsets/byte-counts laid out plane-major. The chunked layout
+	// requires special handling, so dispatch before the standard tile lookup.
+	if ifd.PlanarConfig == 2 && ifd.SamplesPerPixel > 1 {
+		if ifd.Compression != 7 {
+			return nil, fmt.Errorf("planar-separate (PlanarConfiguration=2) is only supported for JPEG-compressed COGs; got compression %d", ifd.Compression)
+		}
+		return r.decodePlanarSeparateJPEG(ifd, col, row, tilesAcross, tilesDown)
+	}
+
 	tileIdx := row*tilesAcross + col
 	if tileIdx >= len(ifd.TileOffsets) || tileIdx >= len(ifd.TileByteCounts) {
 		return nil, fmt.Errorf("tile index %d out of range", tileIdx)
@@ -659,9 +677,28 @@ func decompressLZW(data []byte) ([]byte, error) {
 }
 
 // decodeJPEGTile decodes a JPEG-compressed tile, optionally prepending JPEG tables.
+// When BandConfig.HasNodata is set, the result is materialised as RGBA and pixels
+// whose channels all match the nodata value (within NodataTolerance) are made
+// transparent. Without nodata, the underlying JPEG image is returned as-is to
+// preserve the YCbCr fast path in downstream sampling.
 func (r *Reader) decodeJPEGTile(ifd *IFD, data []byte) (image.Image, error) {
-	var jpegData []byte
+	img, err := decodeJPEGBytes(ifd, data)
+	if err != nil {
+		return nil, err
+	}
+	cfg := r.bandCfg
+	if !cfg.HasNodata {
+		return img, nil
+	}
+	rgba := toRGBA(img)
+	applyNodataMaskRGBA(rgba, uint8(cfg.Nodata), uint8(cfg.NodataTolerance))
+	return rgba, nil
+}
 
+// decodeJPEGBytes is the raw JPEG decode (with JPEGTables prepended if present).
+// It does not apply nodata.
+func decodeJPEGBytes(ifd *IFD, data []byte) (image.Image, error) {
+	var jpegData []byte
 	if len(ifd.JPEGTables) > 0 {
 		// JPEG tables contain the header with quantization/Huffman tables.
 		// Strip the trailing EOI (0xFFD9) from tables and the leading SOI (0xFFD8) from data.
@@ -679,13 +716,163 @@ func (r *Reader) decodeJPEGTile(ifd *IFD, data []byte) (image.Image, error) {
 	} else {
 		jpegData = data
 	}
-
 	img, err := jpeg.Decode(bytes.NewReader(jpegData))
 	if err != nil {
 		return nil, fmt.Errorf("decoding JPEG tile: %w", err)
 	}
-
 	return img, nil
+}
+
+// toRGBA materialises any image.Image into an *image.RGBA. If the input is
+// already RGBA the original is returned (no copy).
+func toRGBA(src image.Image) *image.RGBA {
+	if rgba, ok := src.(*image.RGBA); ok {
+		return rgba
+	}
+	b := src.Bounds()
+	dst := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+	// Use draw via image/color to handle YCbCr/Gray/etc generically.
+	for y := 0; y < b.Dy(); y++ {
+		for x := 0; x < b.Dx(); x++ {
+			rr, gg, bb, aa := src.At(b.Min.X+x, b.Min.Y+y).RGBA()
+			i := dst.PixOffset(x, y)
+			dst.Pix[i+0] = uint8(rr >> 8)
+			dst.Pix[i+1] = uint8(gg >> 8)
+			dst.Pix[i+2] = uint8(bb >> 8)
+			dst.Pix[i+3] = uint8(aa >> 8)
+		}
+	}
+	return dst
+}
+
+// applyNodataMaskRGBA zeroes the alpha (and RGB) of any pixel where every RGB
+// channel is within tol of nodataVal. RGB is also zeroed so consumers that
+// ignore alpha (e.g. JPEG output) at least render a neutral colour.
+func applyNodataMaskRGBA(img *image.RGBA, nodataVal, tol uint8) {
+	pix := img.Pix
+	nd := int(nodataVal)
+	t := int(tol)
+	for i := 0; i+3 < len(pix); i += 4 {
+		if absDiff(int(pix[i+0]), nd) <= t &&
+			absDiff(int(pix[i+1]), nd) <= t &&
+			absDiff(int(pix[i+2]), nd) <= t {
+			pix[i+0] = 0
+			pix[i+1] = 0
+			pix[i+2] = 0
+			pix[i+3] = 0
+		}
+	}
+}
+
+func absDiff(a, b int) int {
+	if a >= b {
+		return a - b
+	}
+	return b - a
+}
+
+// decodePlanarSeparateJPEG handles PlanarConfig=2 (band-interleaved) JPEG COGs.
+// Each band is stored as a separate single-channel JPEG tile; tile offsets are
+// laid out plane-major: [plane0 tiles..., plane1 tiles..., ...].
+//
+// The resulting image is a 4-channel RGBA where R,G,B come from the first three
+// planes (or are duplicated from plane 0 when the file is single-band), and
+// alpha comes from plane 4 if SamplesPerPixel >= 4. Pixels matching the
+// configured nodata value (with tolerance) are made transparent.
+func (r *Reader) decodePlanarSeparateJPEG(ifd *IFD, col, row, tilesAcross, tilesDown int) (image.Image, error) {
+	tilesPerPlane := tilesAcross * tilesDown
+	planes := int(ifd.SamplesPerPixel)
+	if planes < 1 {
+		return nil, fmt.Errorf("planar separate: invalid SamplesPerPixel %d", planes)
+	}
+	tw := int(ifd.TileWidth)
+	th := int(ifd.TileHeight)
+
+	// Decode each plane's tile into a slice of per-pixel uint8 samples.
+	planeSamples := make([][]uint8, planes)
+	for p := 0; p < planes; p++ {
+		idx := p*tilesPerPlane + row*tilesAcross + col
+		if idx >= len(ifd.TileOffsets) || idx >= len(ifd.TileByteCounts) {
+			return nil, fmt.Errorf("planar separate: tile index %d out of range (have %d entries)", idx, len(ifd.TileOffsets))
+		}
+		offset := ifd.TileOffsets[idx]
+		size := ifd.TileByteCounts[idx]
+		if size == 0 {
+			planeSamples[p] = make([]uint8, tw*th) // zero plane
+			continue
+		}
+		end := offset + size
+		if end > uint64(len(r.data)) {
+			return nil, fmt.Errorf("planar separate: tile [%d:%d] exceeds file size %d", offset, end, len(r.data))
+		}
+		img, err := decodeJPEGBytes(ifd, r.data[offset:end])
+		if err != nil {
+			return nil, fmt.Errorf("planar separate plane %d: %w", p, err)
+		}
+		planeSamples[p] = grayBytes(img, tw, th)
+	}
+
+	// Merge planes into RGBA. Default mapping: plane 0→R, 1→G, 2→B, 3→A.
+	out := image.NewRGBA(image.Rect(0, 0, tw, th))
+	pix := out.Pix
+	hasAlphaPlane := planes >= 4
+	for i := 0; i < tw*th; i++ {
+		r0 := planeSamples[0][i]
+		var g0, b0 uint8 = r0, r0
+		if planes >= 2 {
+			g0 = planeSamples[1][i]
+		}
+		if planes >= 3 {
+			b0 = planeSamples[2][i]
+		}
+		var a0 uint8 = 255
+		if hasAlphaPlane {
+			a0 = planeSamples[3][i]
+		}
+		j := i * 4
+		pix[j+0] = r0
+		pix[j+1] = g0
+		pix[j+2] = b0
+		pix[j+3] = a0
+	}
+
+	cfg := r.bandCfg
+	if cfg.HasNodata {
+		applyNodataMaskRGBA(out, uint8(cfg.Nodata), uint8(cfg.NodataTolerance))
+	}
+	return out, nil
+}
+
+// grayBytes extracts a tw×th grayscale byte buffer from a decoded image,
+// handling *image.Gray, *image.YCbCr (Y plane), and the generic fallback.
+func grayBytes(img image.Image, tw, th int) []uint8 {
+	out := make([]uint8, tw*th)
+	switch im := img.(type) {
+	case *image.Gray:
+		// Stride may differ from width; copy row by row.
+		for y := 0; y < th; y++ {
+			srcOff := y * im.Stride
+			dstOff := y * tw
+			copy(out[dstOff:dstOff+tw], im.Pix[srcOff:srcOff+tw])
+		}
+	case *image.YCbCr:
+		// Single-channel JPEG sometimes decodes as YCbCr 4:4:4 with chroma = 128.
+		for y := 0; y < th; y++ {
+			for x := 0; x < tw; x++ {
+				yi := im.YOffset(x, y)
+				out[y*tw+x] = im.Y[yi]
+			}
+		}
+	default:
+		b := img.Bounds()
+		for y := 0; y < th; y++ {
+			for x := 0; x < tw; x++ {
+				c := color.GrayModel.Convert(img.At(b.Min.X+x, b.Min.Y+y)).(color.Gray)
+				out[y*tw+x] = c.Y
+			}
+		}
+	}
+	return out
 }
 
 // decodeRawTile decodes an uncompressed tile.
@@ -753,10 +940,14 @@ func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 	// Used for multi-band or 16-bit data not handled by the legacy path.
 	var genHasNodata bool
 	var genNodataU16 uint16
+	var genNodataTol uint16
 	if !useLegacyNodata {
 		if cfg.HasNodata {
 			genHasNodata = true
 			genNodataU16 = uint16(cfg.Nodata)
+			if cfg.NodataTolerance > 0 {
+				genNodataTol = uint16(cfg.NodataTolerance)
+			}
 		} else if nd := r.ifds[0].NoData; nd != "" {
 			if v, err := strconv.ParseFloat(strings.TrimSpace(nd), 64); err == nil && v >= 0 && v <= 65535 && v == math.Floor(v) {
 				genHasNodata = true
@@ -846,7 +1037,14 @@ func (r *Reader) decodeRawTile(ifd *IFD, data []byte) (image.Image, error) {
 			if genHasNodata && effectiveAlpha < 0 {
 				isNodata := true
 				for b := 0; b < spp; b++ {
-					if readSample(pixelOff, b) != genNodataU16 {
+					s := readSample(pixelOff, b)
+					var diff uint16
+					if s >= genNodataU16 {
+						diff = s - genNodataU16
+					} else {
+						diff = genNodataU16 - s
+					}
+					if diff > genNodataTol {
 						isNodata = false
 						break
 					}


### PR DESCRIPTION
JPEG-compressed source tiles were silently ignoring --nodata because decodeJPEGTile returned the decoded image without consulting BandConfig. Add a --nodata-tolerance flag for lossy-JPEG borders smeared above the exact nodata value, auto-switch the output format jpeg → webp when nodata is active and the user didn't pick a format, and add a planar- separate (PlanarConfiguration=2) JPEG decode path that merges per-plane tiles into RGBA instead of returning only plane 0.