### PR TITLE
fix: support non-square pixels in resampling

### DIFF
--- a/internal/cog/reader.go
+++ b/internal/cog/reader.go
@@ -1615,6 +1615,13 @@ func (r *Reader) IFDPixelSize(level int) float64 {
 	return r.geo.PixelSizeX * float64(r.ifds[0].Width) / float64(r.ifds[level].Width)
 }
 
+// IFDPixelSizeY returns the pixel size in the Y direction (CRS units) for the
+// given IFD level. Unlike IFDPixelSize which uses Width-based scaling, this
+// uses Height-based scaling for non-square pixels.
+func (r *Reader) IFDPixelSizeY(level int) float64 {
+	return math.Abs(r.geo.PixelSizeY) * float64(r.ifds[0].Height) / float64(r.ifds[level].Height)
+}
+
 func (r *Reader) IFDWidth(level int) int {
 	return int(r.ifds[level].Width)
 }

--- a/internal/tile/resample.go
+++ b/internal/tile/resample.go
@@ -75,7 +75,8 @@ type tileSource struct {
 	maxCRSX        float64
 	maxCRSY        float64
 	level          int
-	levelPixelSize float64
+	levelPixelSize  float64
+	levelPixelSizeY float64
 	imgW           int
 	imgH           int
 	tileW          int // source tile width (pixels per COG tile)
@@ -98,18 +99,19 @@ func prepareTileSources(srcInfos []sourceInfo, outputResCRS float64, tileMinCRSX
 		level := src.reader.OverviewForZoom(outputResCRS)
 		ifd := src.reader.IFDTileSize(level)
 		result = append(result, tileSource{
-			reader:         src.reader,
-			geo:            src.geo,
-			minCRSX:        src.minCRSX,
-			minCRSY:        src.minCRSY,
-			maxCRSX:        src.maxCRSX,
-			maxCRSY:        src.maxCRSY,
-			level:          level,
-			levelPixelSize: src.reader.IFDPixelSize(level),
-			imgW:           src.reader.IFDWidth(level),
-			imgH:           src.reader.IFDHeight(level),
-			tileW:          ifd[0],
-			tileH:          ifd[1],
+			reader:          src.reader,
+			geo:             src.geo,
+			minCRSX:         src.minCRSX,
+			minCRSY:         src.minCRSY,
+			maxCRSX:         src.maxCRSX,
+			maxCRSY:         src.maxCRSY,
+			level:           level,
+			levelPixelSize:  src.reader.IFDPixelSize(level),
+			levelPixelSizeY: src.reader.IFDPixelSizeY(level),
+			imgW:            src.reader.IFDWidth(level),
+			imgH:            src.reader.IFDHeight(level),
+			tileW:           ifd[0],
+			tileH:           ifd[1],
 		})
 	}
 	return result
@@ -211,7 +213,7 @@ func sampleFromTileSources(sources []tileSource, srcX, srcY float64, cache *cog.
 
 		// Convert CRS coordinates to pixel coordinates using pre-computed level data.
 		pixX := (srcX - src.geo.OriginX) / src.levelPixelSize
-		pixY := (src.geo.OriginY - srcY) / src.levelPixelSize
+		pixY := (src.geo.OriginY - srcY) / src.levelPixelSizeY
 
 		// Check bounds.
 		if pixX < 0 || pixX >= float64(src.imgW) || pixY < 0 || pixY >= float64(src.imgH) {
@@ -1519,7 +1521,7 @@ func sampleFromTileSourcesFloat(sources []tileSource, nodataValues []float64, sr
 		}
 
 		pixX := (srcX - src.geo.OriginX) / src.levelPixelSize
-		pixY := (src.geo.OriginY - srcY) / src.levelPixelSize
+		pixY := (src.geo.OriginY - srcY) / src.levelPixelSizeY
 
 		if pixX < 0 || pixX >= float64(src.imgW) || pixY < 0 || pixY >= float64(src.imgH) {
 			continue


### PR DESCRIPTION
## Summary

Fix Y-axis pixel coordinate computation when PixelSizeX ≠ PixelSizeY (non-square pixels).

## Bug

The code used `levelPixelSize` (X-axis resolution) for both X and Y pixel coordinate calculations. For non-square pixel images, this causes a proportional Y offset error.

## Fix

- **reader.go**: Added `IFDPixelSizeY()` method that uses Height-based scaling for Y-axis resolution, matching `IFDPixelSize()` which uses Width-based scaling for X-axis
- **resample.go**: Added `levelPixelSizeY` field to `tileSource` struct. Two pixel coordinate lookup sites now use Y-axis resolution for the Y component

## Changes

| File | +/- |
|------|-----|
| `internal/cog/reader.go` | +7 |
| `internal/tile/resample.go` | +17/-15 |